### PR TITLE
DC-916: Allowing PTA showing messages link for PAYE (NINO) users as well

### DIFF
--- a/app/controllers/MessageController.scala
+++ b/app/controllers/MessageController.scala
@@ -52,7 +52,7 @@ class MessageController @Inject() (
   def messageList = ProtectedAction(baseBreadcrumb) {
     implicit pertaxContext =>
       enforceGovernmentGatewayUser {
-        enforceSaUser {
+        enforcePayeOrSaUser {
           messagePartialService.getMessageListPartial map { p =>
             Ok(views.html.message.messageInbox(messageListPartial = p successfulContentOrElse Html(Messages("label.sorry_theres_been_a_technical_problem_retrieving_your_messages"))))
           }
@@ -63,7 +63,7 @@ class MessageController @Inject() (
   def messageDetail(messageReadUrl: String) = ProtectedAction(messageBreadcrumb) {
     implicit pertaxContext =>
       enforceGovernmentGatewayUser {
-        enforceSaUser {
+        enforcePayeOrSaUser {
           messagePartialService.getMessageDetailPartial(messageReadUrl).map {
             case HtmlPartial.Success(Some(title), content) => Ok(views.html.message.messageDetail(message = content, title = title))
             case HtmlPartial.Success(None, content) => Ok(views.html.message.messageDetail(message = content, title = Messages("label.message")))

--- a/app/controllers/auth/AuthorisedActions.scala
+++ b/app/controllers/auth/AuthorisedActions.scala
@@ -192,4 +192,7 @@ trait AuthorisedActions extends PublicActions with ConfidenceLevelAndCredentialS
 
   def enforceSaUser(block: => Future[Result])(implicit pertaxContext: PertaxContext) =
     PertaxUser.ifSaUser(block) getOrElse renderError(pertaxContext, UNAUTHORIZED)
+
+  def enforcePayeOrSaUser(block: => Future[Result])(implicit pertaxContext: PertaxContext) =
+    PertaxUser.ifPayeOrSaUser(block) getOrElse renderError(pertaxContext, UNAUTHORIZED)
 }

--- a/app/models/PertaxUser.scala
+++ b/app/models/PertaxUser.scala
@@ -138,6 +138,7 @@ object PertaxUser {
   def ifVerifyUser[T](block: => T)(implicit pertaxContext: PertaxContext)                        = ifUserPredicate(_.isVerify)(u => block)
   def ifHighGovernmentGatewayOrVerifyUser[T](block: => T)(implicit pertaxContext: PertaxContext) = ifUserPredicate(_.isHighGovernmentGatewayOrVerify)(u => block)
   def ifSaUser[T](block: => T)(implicit pertaxContext: PertaxContext)                            = ifUserPredicate(_.isSa)(u => block)
+  def ifPayeOrSaUser[T](block: => T)(implicit pertaxContext: PertaxContext)                      = ifUserPredicate(u => u.isSa || u.isPaye)(u => block)
   def ifPayeUser[T](block: => T)(implicit pertaxContext: PertaxContext)                          = ifUserPredicate(_.isPaye)(u => block)
   def ifPayeUserLoanNino[T](block: Nino => T)(implicit pertaxContext: PertaxContext)             = ifUserPredicate(_.isPaye)(u => u.nino.map(block))
   def ifNonDelegatingUser[T](block: => T)(implicit pertaxContext: PertaxContext)                 = ifUserPredicate(!_.authContext.isDelegating)(u => block)

--- a/test/controllers/MessageControllerSpec.scala
+++ b/test/controllers/MessageControllerSpec.scala
@@ -75,7 +75,7 @@ class MessageControllerSpec extends BaseSpec  {
 
   "Calling MessageController.messageList" should {
 
-    "call messages and return 200 when called by a high GG user" in new LocalSetup {
+    "call messages and return 200 when called by a high sa  GG user" in new LocalSetup {
 
       lazy val authProviderType = UserDetails.GovernmentGatewayAuthProvider
 
@@ -92,6 +92,29 @@ class MessageControllerSpec extends BaseSpec  {
 
       verify(controller.messagePartialService, times(1)).getMessageListPartial(any())
       verify(controller.citizenDetailsService, times(0)).personDetails(any())(any())
+    }
+
+    "call messages and return 200 when called by a high paye GG user" in new LocalSetup {
+
+      lazy val authProviderType = UserDetails.GovernmentGatewayAuthProvider
+
+      when(controller.citizenDetailsService.personDetails(meq(Fixtures.fakeNino))(any())) thenReturn {
+        Future.successful(PersonDetailsSuccessResponse(Fixtures.buildPersonDetails))
+      }
+
+      when(controller.authConnector.currentAuthority(org.mockito.Matchers.any())) thenReturn {
+        Future.successful(Some(buildFakeAuthority(withPaye = true, withSa = false, confidenceLevel = ConfidenceLevel.L200)))
+      }
+
+      when(controller.messagePartialService.getMessageListPartial(any())) thenReturn {
+        Future(HtmlPartial.Success(Some("Success"),Html("<title/>")))
+      }
+
+      val r = controller.messageList(buildFakeRequestWithAuth("GET"))
+      status(r) shouldBe OK
+
+      verify(controller.messagePartialService, times(1)).getMessageListPartial(any())
+      verify(controller.citizenDetailsService, times(1)).personDetails(any())(any())
     }
 
     "return 401 for a high GG user for a high GG user not enrolled in SA" in new LocalSetup {
@@ -148,7 +171,7 @@ class MessageControllerSpec extends BaseSpec  {
 
   "Calling MessageController.messageDetail" should {
 
-    "call messages and return 200 when called by a high GG" in new LocalSetup {
+    "call messages and return 200 when called by a SA high GG" in new LocalSetup {
 
       lazy val authProviderType = UserDetails.GovernmentGatewayAuthProvider
 
@@ -164,6 +187,28 @@ class MessageControllerSpec extends BaseSpec  {
       status(r) shouldBe OK
       verify(controller.messagePartialService, times(1)).getMessageDetailPartial(any())(any())
       verify(controller.citizenDetailsService, times(0)).personDetails(any())(any())
+    }
+
+    "call messages and return 200 when called by a high PAYE GG" in new LocalSetup {
+
+      lazy val authProviderType = UserDetails.GovernmentGatewayAuthProvider
+
+      when(controller.citizenDetailsService.personDetails(meq(Fixtures.fakeNino))(any())) thenReturn {
+        Future.successful(PersonDetailsSuccessResponse(Fixtures.buildPersonDetails))
+      }
+
+      when(controller.authConnector.currentAuthority(org.mockito.Matchers.any())) thenReturn {
+        Future.successful(Some(buildFakeAuthority(withPaye = true, withSa = false, confidenceLevel = ConfidenceLevel.L200)))
+      }
+
+      when(controller.messagePartialService.getMessageDetailPartial(any())(any())) thenReturn {
+        Future(HtmlPartial.Success(Some("Success"),Html("<title/>")))
+      }
+
+      val r = controller.messageDetail("")(buildFakeRequestWithAuth("GET"))
+      status(r) shouldBe OK
+      verify(controller.messagePartialService, times(1)).getMessageDetailPartial(any())(any())
+      verify(controller.citizenDetailsService, times(1)).personDetails(any())(any())
     }
 
     "return 401 for a high GG user not enrolled in SA" in new LocalSetup {


### PR DESCRIPTION
As required by story https://jira.tools.tax.service.gov.uk/browse/DC-916
Personal Tax should allow NINO users (PAYE) to see the Messages link as well.