### PR TITLE
MTA-3142 changed local portal address to specify https localhost only

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -223,7 +223,7 @@ external-url {
     host = "http://localhost:9242"
   }
   portal {
-    host = "http://localhost:9242"
+    host = "https://localhost"
   }
   pensions-lifetime-allowance {
     host = "http://localhost:9011"


### PR DESCRIPTION
http://localhost:9025/ssoout/non-digital?continue=https%3A%2F%2Flocalhost%2Fself-assessment-file%2F1617%2Find%2F1097172564%2Freturn%2Fwelcome%3Flang%3Deng

is the external portal address. Copy the continue url

https%3A%2F%2Flocalhost%2Fself-assessment-file%2F1617%2Find%2F1097172564%2Freturn%2Fwelcome%3Flang%3Deng

decode the url

https://localhost/self-assessment-file/1617/ind/1097172564/return/welcome?lang=eng

Paste this into a broswer and the if the local portal is running it will be shown.

