### PR TITLE
DDCNLS-6703: simplifying auth actions to not require enrolments

### DIFF
--- a/app/controllers/auth/AuthAction.scala
+++ b/app/controllers/auth/AuthAction.scala
@@ -46,7 +46,7 @@ class AuthActionImpl @Inject()(
 
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
-    authorised((Enrolment("IR-SA") or Nino(hasNino = true)) and ConfidenceLevel.L200)
+    authorised(ConfidenceLevel.L200)
       .retrieve(
         Retrievals.nino and
           Retrievals.allEnrolments and

--- a/app/controllers/auth/MinimumAuthAction.scala
+++ b/app/controllers/auth/MinimumAuthAction.scala
@@ -44,7 +44,7 @@ class MinimumAuthAction @Inject()(
 
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
-    authorised((Enrolment("IR-SA") or Nino(hasNino = true)) and ConfidenceLevel.L50)
+    authorised(ConfidenceLevel.L50)
       .retrieve(
         Retrievals.nino and
           Retrievals.allEnrolments and


### PR DESCRIPTION
*Nino predicate doesnt work in the expected way, simplify auth predicates to what is strictly necessary
