### PR TITLE
move some features toggles to mongo

### DIFF
--- a/app/config/ConfigDecorator.scala
+++ b/app/config/ConfigDecorator.scala
@@ -35,6 +35,9 @@ class ConfigDecorator @Inject() (
 ) extends TaxcalcUrls {
   lazy val authProviderChoice = runModeConfiguration.get[String](s"external-url.auth-provider-choice.host")
 
+  lazy val internalAuthResourceType: String =
+    runModeConfiguration.getOptional[String]("internal-auth.resource-type").getOrElse("ddcn-live-admin-frontend")
+
   val defaultOrigin = Origin("PERTAX")
 
   val authProviderKey = "AuthProvider"
@@ -172,6 +175,8 @@ class ConfigDecorator @Inject() (
       .orElse(runModeConfiguration.getOptional[String]("appName"))
       .getOrElse("undefined")
 
+  val ehCacheTtlInSeconds = runModeConfiguration.getOptional[Int]("ehCache.ttlInSeconds").getOrElse(600)
+
   lazy val hmrcProblemsSigningIn = "https://www.gov.uk/log-in-register-hmrc-online-services/problems-signing-in"
   lazy val generalQueriesUrl     = "https://www.gov.uk/contact-hmrc"
 
@@ -240,8 +245,6 @@ class ConfigDecorator @Inject() (
   lazy val singleAccountEnrolmentFeature =
     runModeConfiguration.getOptional[String]("feature.single-account-enrolment.enabled").getOrElse("false").toBoolean
 
-  lazy val taxcalcEnabled       =
-    runModeConfiguration.getOptional[String]("feature.taxcalc.enabled").getOrElse("true").toBoolean
   lazy val taxComponentsEnabled =
     runModeConfiguration.getOptional[String]("feature.tax-components.enabled").getOrElse("true").toBoolean
 
@@ -257,11 +260,6 @@ class ConfigDecorator @Inject() (
 
   lazy val personDetailsMessageCountEnabled =
     runModeConfiguration.getOptional[String]("feature.person-details-message-count.enabled").getOrElse("true").toBoolean
-
-  lazy val addressChangeTaxCreditsQuestionEnabled = runModeConfiguration
-    .getOptional[String]("feature.address-change-tax-credits-question.enabled")
-    .getOrElse("false")
-    .toBoolean
 
   lazy val updateInternationalAddressInPta =
     runModeConfiguration
@@ -300,12 +298,6 @@ class ConfigDecorator @Inject() (
   lazy val editAddressTtl: Int = runModeConfiguration.getOptional[Int]("mongodb.editAddressTtl").getOrElse(0)
 
   lazy val saPartialReturnLinkText = "Back to account home"
-
-  lazy val isNationalInsuranceCardEnabled: Boolean =
-    runModeConfiguration
-      .getOptional[String]("feature.national-insurance-tile.enabled")
-      .getOrElse("false")
-      .toBoolean
 
   lazy val manageTrustedHelpersUrl = s"$fandfFrontendHost/trusted-helpers/select-a-service"
   lazy val seissClaimsUrl          = s"$seissFrontendHost/self-employment-support/claim/your-claims"

--- a/app/controllers/address/DoYouLiveInTheUKController.scala
+++ b/app/controllers/address/DoYouLiveInTheUKController.scala
@@ -16,6 +16,7 @@
 
 package controllers.address
 
+import cats.data.OptionT
 import com.google.inject.Inject
 import config.ConfigDecorator
 import controllers.auth.AuthJourney

--- a/app/controllers/address/TaxCreditsChoiceController.scala
+++ b/app/controllers/address/TaxCreditsChoiceController.scala
@@ -22,11 +22,13 @@ import controllers.auth.AuthJourney
 import controllers.bindable.AddrType
 import controllers.controllershelpers.AddressJourneyCachingHelper
 import models.TaxCreditsChoiceId
-import models.dto.{AddressFinderDto, TaxCreditsChoiceDto}
+import models.admin.AddressTaxCreditsBrokerCallToggle
+import models.dto.TaxCreditsChoiceDto
 import play.api.Logging
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.EditAddressLockRepository
-import services.TaxCreditsService
+import services.admin.FeatureFlagService
+import services.{LocalSessionCache, TaxCreditsService}
 import views.html.InternalServerErrorView
 import views.html.interstitial.DisplayAddressInterstitialView
 import views.html.personaldetails.TaxCreditsChoiceView
@@ -40,62 +42,72 @@ class TaxCreditsChoiceController @Inject() (
   editAddressLockRepository: EditAddressLockRepository,
   displayAddressInterstitialView: DisplayAddressInterstitialView,
   taxCreditsService: TaxCreditsService,
+  featureFlagService: FeatureFlagService,
   internalServerErrorView: InternalServerErrorView,
-  taxCreditsChoiceView: TaxCreditsChoiceView
+  taxCreditsChoiceView: TaxCreditsChoiceView,
+  val sessionCache: LocalSessionCache
 )(implicit configDecorator: ConfigDecorator, ec: ExecutionContext)
     extends AddressController(authJourney, cc, displayAddressInterstitialView)
     with Logging {
 
   def onPageLoad: Action[AnyContent] = authenticate.async { implicit request =>
     addressJourneyEnforcer { nino => _ =>
-      val result = if (configDecorator.addressChangeTaxCreditsQuestionEnabled) {
-        Future.successful(
-          Ok(taxCreditsChoiceView(TaxCreditsChoiceDto.form, configDecorator.tcsChangeAddressUrl))
-        )
-      } else {
-        taxCreditsService.checkForTaxCredits(Some(nino)).map {
-          case Some(true)  =>
-            cachingHelper.addToCache(TaxCreditsChoiceId, TaxCreditsChoiceDto(true))
-            Redirect(configDecorator.tcsChangeAddressUrl)
-          case Some(false) =>
-            cachingHelper.addToCache(TaxCreditsChoiceId, TaxCreditsChoiceDto(false))
-            Redirect(routes.DoYouLiveInTheUKController.onPageLoad)
-          case None        =>
-            InternalServerError(internalServerErrorView())
+      featureFlagService
+        .get(AddressTaxCreditsBrokerCallToggle)
+        .flatMap { toggle =>
+          if (toggle.isEnabled) {
+            taxCreditsService.checkForTaxCredits(Some(nino)).map {
+              case Some(true)  =>
+                cachingHelper.addToCache(TaxCreditsChoiceId, TaxCreditsChoiceDto(true))
+                Redirect(configDecorator.tcsChangeAddressUrl)
+              case Some(false) =>
+                cachingHelper.addToCache(TaxCreditsChoiceId, TaxCreditsChoiceDto(false))
+                Redirect(routes.DoYouLiveInTheUKController.onPageLoad)
+              case None        =>
+                InternalServerError(internalServerErrorView())
+            }
+          } else {
+            Future.successful(
+              Ok(taxCreditsChoiceView(TaxCreditsChoiceDto.form, configDecorator.tcsChangeAddressUrl))
+            )
+          }
         }
-      }
-      result.flatMap(cachingHelper.enforceDisplayAddressPageVisited(_))
+        .flatMap(cachingHelper.enforceDisplayAddressPageVisited)
     }
   }
 
   def onSubmit: Action[AnyContent] =
     authenticate.async { implicit request =>
-      if (configDecorator.addressChangeTaxCreditsQuestionEnabled) {
-        addressJourneyEnforcer { _ => _ =>
-          TaxCreditsChoiceDto.form.bindFromRequest.fold(
-            formWithErrors =>
-              Future.successful(BadRequest(taxCreditsChoiceView(formWithErrors, configDecorator.tcsChangeAddressUrl))),
-            taxCreditsChoiceDto =>
-              cachingHelper.addToCache(TaxCreditsChoiceId, taxCreditsChoiceDto) map { _ =>
-                if (taxCreditsChoiceDto.hasTaxCredits) {
-                  editAddressLockRepository
-                    .insert(
-                      request.nino.get.withoutSuffix,
-                      AddrType.apply("residential").get
-                    )
-                    .map {
-                      case true => logger.warn("Address locked for tcs users")
-                      case _    => logger.error(s"Could not insert address lock for user $request.nino.get.withoutSuffix")
-                    }
-                  Redirect(configDecorator.tcsChangeAddressUrl)
-                } else {
-                  Redirect(routes.DoYouLiveInTheUKController.onPageLoad)
+      featureFlagService.get(AddressTaxCreditsBrokerCallToggle).flatMap { featureFlag =>
+        if (featureFlag.isEnabled) {
+          Future.successful(Redirect(routes.PersonalDetailsController.onPageLoad))
+        } else {
+          addressJourneyEnforcer { _ => _ =>
+            TaxCreditsChoiceDto.form.bindFromRequest.fold(
+              formWithErrors =>
+                Future
+                  .successful(BadRequest(taxCreditsChoiceView(formWithErrors, configDecorator.tcsChangeAddressUrl))),
+              taxCreditsChoiceDto =>
+                cachingHelper.addToCache(TaxCreditsChoiceId, taxCreditsChoiceDto) map { _ =>
+                  if (taxCreditsChoiceDto.hasTaxCredits) {
+                    editAddressLockRepository
+                      .insert(
+                        request.nino.get.withoutSuffix,
+                        AddrType.apply("residential").get
+                      )
+                      .map {
+                        case true => logger.warn("Address locked for tcs users")
+                        case _    =>
+                          logger.error(s"Could not insert address lock for user $request.nino.get.withoutSuffix")
+                      }
+                    Redirect(configDecorator.tcsChangeAddressUrl)
+                  } else {
+                    Redirect(routes.DoYouLiveInTheUKController.onPageLoad)
+                  }
                 }
-              }
-          )
+            )
+          }
         }
-      } else {
-        Future.successful(Redirect(routes.PersonalDetailsController.onPageLoad))
       }
     }
 }

--- a/app/controllers/admin/FeatureFlagsAdminController.scala
+++ b/app/controllers/admin/FeatureFlagsAdminController.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.admin
+
+import controllers.auth.InternalAuthAction
+import models.admin.{FeatureFlag, FeatureFlagName}
+import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+import services.admin.FeatureFlagService
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import util.AuditServiceTools
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class FeatureFlagsAdminController @Inject() (
+  val auth: InternalAuthAction,
+  featureFlagService: FeatureFlagService,
+  cc: ControllerComponents
+)(implicit ec: ExecutionContext)
+    extends AbstractController(cc) {
+
+  def get: Action[AnyContent] = auth().async {
+    featureFlagService.getAll
+      .map(flags => Ok(Json.toJson(flags)))
+  }
+
+  def put(flagName: FeatureFlagName): Action[AnyContent] = auth().async { request =>
+    request.body.asJson match {
+      case Some(JsBoolean(enabled)) =>
+        featureFlagService
+          .set(flagName, enabled)
+          .map(_ => NoContent)
+      case _                        =>
+        Future.successful(BadRequest)
+    }
+  }
+
+  def putAll: Action[AnyContent] = auth().async { request =>
+    val flags = request.body.asJson
+      .map(_.as[Seq[FeatureFlag]])
+      .getOrElse(Seq.empty)
+      .map(flag => (flag.name -> flag.isEnabled))
+      .toMap
+    featureFlagService.setAll(flags).map(_ => NoContent)
+  }
+}

--- a/app/controllers/auth/InternalAuthAction.scala
+++ b/app/controllers/auth/InternalAuthAction.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.auth
+
+import com.google.inject.Inject
+import config.ConfigDecorator
+import play.api.Logging
+import uk.gov.hmrc.internalauth.client.Predicate.Permission
+import uk.gov.hmrc.internalauth.client._
+
+import scala.concurrent.ExecutionContext
+
+class InternalAuthAction @Inject() (
+  configDecorator: ConfigDecorator,
+  internalAuth: BackendAuthComponents
+)(implicit
+  val executionContext: ExecutionContext
+) extends Logging {
+
+  private val permission: Permission =
+    Permission(
+      resource = Resource(
+        resourceType = ResourceType(configDecorator.internalAuthResourceType),
+        resourceLocation = ResourceLocation("*")
+      ),
+      action = IAAction("ADMIN")
+    )
+
+  def apply() =
+    internalAuth.authorizedAction(permission, Retrieval.username)
+}

--- a/app/controllers/controllershelpers/AddressJourneyCachingHelper.scala
+++ b/app/controllers/controllershelpers/AddressJourneyCachingHelper.scala
@@ -18,7 +18,7 @@ package controllers.controllershelpers
 
 import cats.data.OptionT
 import com.google.inject.{Inject, Singleton}
-import controllers.bindable.AddrType
+import controllers.bindable.{AddrType, ResidentialAddrType}
 import models._
 import models.addresslookup.{AddressRecord, RecordSet}
 import models.dto._

--- a/app/controllers/controllershelpers/HomeCardGenerator.scala
+++ b/app/controllers/controllershelpers/HomeCardGenerator.scala
@@ -16,20 +16,30 @@
 
 package controllers.controllershelpers
 
+import cats.implicits._
+import cats.instances.list._
+import cats.syntax.traverse._
+import cats.syntax.all._
+import cats.data.OptionT
 import com.google.inject.{Inject, Singleton}
 import config.{ConfigDecorator, NewsAndTilesConfig}
 import controllers.auth.requests.UserRequest
 import models._
+import models.admin.NationalInsuranceTileToggle
 import play.api.i18n.Messages
 import play.api.mvc.AnyContent
 import play.twirl.api.{Html, HtmlFormat}
+import services.admin.FeatureFlagService
 import util.DateTimeTools.{current, previousAndCurrentTaxYear}
 import util.EnrolmentsHelper
 import viewmodels.TaxCalculationViewModel
 import views.html.cards.home._
 
+import scala.concurrent.{ExecutionContext, Future}
+
 @Singleton
 class HomeCardGenerator @Inject() (
+  featureFlagService: FeatureFlagService,
   payAsYouEarnView: PayAsYouEarnView,
   taxCalculationView: TaxCalculationView,
   selfAssessmentView: SelfAssessmentView,
@@ -44,7 +54,7 @@ class HomeCardGenerator @Inject() (
   saAndItsaMergeView: SaAndItsaMergeView,
   enrolmentsHelper: EnrolmentsHelper,
   newsAndTilesConfig: NewsAndTilesConfig
-)(implicit configDecorator: ConfigDecorator) {
+)(implicit configDecorator: ConfigDecorator, ex: ExecutionContext) {
 
   def getIncomeCards(
     taxComponentsState: TaxComponentsState,
@@ -52,24 +62,30 @@ class HomeCardGenerator @Inject() (
     taxCalculationStateCyMinusTwo: Option[TaxYearReconciliation],
     saActionNeeded: SelfAssessmentUserType,
     showSeissCard: Boolean
-  )(implicit request: UserRequest[AnyContent], messages: Messages): Seq[Html] =
-    List(
-      getLatestNewsAndUpdatesCard(),
-      getPayAsYouEarnCard(taxComponentsState),
-      getTaxCalculationCard(taxCalculationStateCyMinusOne),
-      getTaxCalculationCard(taxCalculationStateCyMinusTwo),
-      getSaAndItsaMergeCard(),
-      getSelfAssessmentCard(saActionNeeded),
-      if (showSeissCard && configDecorator.isSeissTileEnabled && !configDecorator.saItsaTileEnabled)
-        Some(seissView())
-      else None,
-      getNationalInsuranceCard(),
-      if (request.trustedHelper.isEmpty) {
-        getAnnualTaxSummaryCard
-      } else {
-        None
-      }
-    ).flatten
+  )(implicit request: UserRequest[AnyContent], messages: Messages): Future[Seq[Html]] =
+    Future
+      .sequence(
+        List(
+          Future.successful(getLatestNewsAndUpdatesCard()),
+          Future.successful(getPayAsYouEarnCard(taxComponentsState)),
+          Future.successful(getTaxCalculationCard(taxCalculationStateCyMinusOne)),
+          Future.successful(getTaxCalculationCard(taxCalculationStateCyMinusTwo)),
+          Future.successful(getSaAndItsaMergeCard()),
+          Future.successful(getSelfAssessmentCard(saActionNeeded)),
+          Future.successful(
+            if (showSeissCard && configDecorator.isSeissTileEnabled && !configDecorator.saItsaTileEnabled)
+              Some(seissView())
+            else None
+          ),
+          getNationalInsuranceCard(),
+          Future.successful(if (request.trustedHelper.isEmpty) {
+            getAnnualTaxSummaryCard
+          } else {
+            None
+          })
+        )
+      )
+      .map(_.flatten)
 
   def getPayAsYouEarnCard(
     taxComponentsState: TaxComponentsState
@@ -143,11 +159,12 @@ class HomeCardGenerator @Inject() (
       None
     }
 
-  def getNationalInsuranceCard()(implicit messages: Messages): Option[HtmlFormat.Appendable] =
-    if (configDecorator.isNationalInsuranceCardEnabled) {
-      Some(nationalInsuranceView())
-    } else {
-      None
+  def getNationalInsuranceCard()(implicit messages: Messages): Future[Option[HtmlFormat.Appendable]] =
+    featureFlagService.get(NationalInsuranceTileToggle).map { toggle =>
+      if (toggle.isEnabled)
+        Some(nationalInsuranceView())
+      else
+        None
     }
 
   def getBenefitCards(

--- a/app/controllers/testOnly/FeatureFlagsController.scala
+++ b/app/controllers/testOnly/FeatureFlagsController.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.testOnly
+
+import controllers.PertaxBaseController
+import models.admin.FeatureFlagName
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.admin.FeatureFlagService
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton()
+class FeatureFlagsController @Inject() (
+  cc: MessagesControllerComponents,
+  featureFlagService: FeatureFlagService
+)(implicit ec: ExecutionContext)
+    extends PertaxBaseController(cc) {
+
+  def setFlag(featureFlagName: FeatureFlagName, isEnabled: Boolean): Action[AnyContent] = Action.async { request =>
+    featureFlagService.set(featureFlagName, isEnabled).map {
+      case true  => Ok(s"Flag $featureFlagName set to $isEnabled")
+      case false => InternalServerError(s"Error while setting flag $featureFlagName to $isEnabled")
+    }
+  }
+}

--- a/app/models/admin/FeatureFlag.scala
+++ b/app/models/admin/FeatureFlag.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.admin
+
+import play.api.libs.json._
+import play.api.mvc.PathBindable
+
+case class FeatureFlag(
+  name: FeatureFlagName,
+  isEnabled: Boolean,
+  description: Option[String] = None
+)
+
+object FeatureFlag {
+  implicit val format: OFormat[FeatureFlag] = Json.format[FeatureFlag]
+}
+
+sealed trait FeatureFlagName {
+  val description: Option[String] = None
+}
+
+object FeatureFlagName {
+  implicit val writes: Writes[FeatureFlagName] = new Writes[FeatureFlagName] {
+    override def writes(o: FeatureFlagName): JsValue = JsString(o.toString)
+  }
+
+  implicit val reads: Reads[FeatureFlagName] = new Reads[FeatureFlagName] {
+    override def reads(json: JsValue): JsResult[FeatureFlagName] =
+      json match {
+        case name if name == JsString(AddressTaxCreditsBrokerCallToggle.toString) =>
+          JsSuccess(AddressTaxCreditsBrokerCallToggle)
+        case name if name == JsString(TaxcalcToggle.toString)                     => JsSuccess(TaxcalcToggle)
+        case name if name == JsString(NationalInsuranceTileToggle.toString)       => JsSuccess(NationalInsuranceTileToggle)
+        case _                                                                    => JsError("Unknown FeatureFlagName")
+      }
+  }
+
+  implicit val formats: Format[FeatureFlagName] =
+    Format(reads, writes)
+
+  implicit def pathBindable: PathBindable[FeatureFlagName] = new PathBindable[FeatureFlagName] {
+
+    override def bind(key: String, value: String): Either[String, FeatureFlagName] =
+      JsString(value).validate[FeatureFlagName] match {
+        case JsSuccess(name, _) =>
+          Right(name)
+        case _                  =>
+          Left(s"The feature flag `$value` does not exist")
+      }
+
+    override def unbind(key: String, value: FeatureFlagName): String =
+      value.toString
+  }
+
+  val allFeatureFlags = List(AddressTaxCreditsBrokerCallToggle, TaxcalcToggle, NationalInsuranceTileToggle)
+}
+
+case object AddressTaxCreditsBrokerCallToggle extends FeatureFlagName {
+  override def toString: String = "address-tax-credits-broker-call"
+  override val description      = Some("If enabled do not ask tax credits question but call tax-credits-broker instead")
+}
+
+case object TaxcalcToggle extends FeatureFlagName {
+  override def toString: String            = "taxcalc"
+  override val description: Option[String] = Some("Enable/disable the tile for payments and repayments")
+}
+
+case object NationalInsuranceTileToggle extends FeatureFlagName {
+  override def toString: String            = "national-insurance-tile"
+  override val description: Option[String] = Some("Enable/disable the tile for check your state pension")
+}
+
+object FeatureFlagMongoFormats {
+  implicit val formats: Format[FeatureFlag] =
+    Json.format[FeatureFlag]
+}

--- a/app/repositories/admin/FeatureFlagRepository.scala
+++ b/app/repositories/admin/FeatureFlagRepository.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories.admin
+
+import models.admin.FeatureFlagName.allFeatureFlags
+import models.admin.{FeatureFlag, FeatureFlagName, TaxcalcToggle}
+import org.mongodb.scala.model.Filters._
+import org.mongodb.scala.model._
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
+import uk.gov.hmrc.mongo.transaction.{TransactionConfiguration, Transactions}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class FeatureFlagRepository @Inject() (
+  val mongoComponent: MongoComponent
+)(implicit
+  ec: ExecutionContext
+) extends PlayMongoRepository[FeatureFlag](
+      collectionName = "admin-feature-flags",
+      mongoComponent = mongoComponent,
+      domainFormat = FeatureFlag.format,
+      indexes = Seq(
+        IndexModel(
+          keys = Indexes.ascending("name"),
+          indexOptions = IndexOptions()
+            .name("name")
+            .unique(true)
+        )
+      ),
+      extraCodecs = Codecs.playFormatSumCodecs(FeatureFlagName.formats)
+    )
+    with Transactions {
+
+  private implicit val tc = TransactionConfiguration.strict
+
+  def getFeatureFlag(name: FeatureFlagName): Future[Option[FeatureFlag]] =
+    collection
+      .find(Filters.equal("name", name.toString))
+      .headOption()
+
+  def getAllFeatureFlags: Future[List[FeatureFlag]] =
+    collection
+      .find()
+      .toFuture()
+      .map(_.toList)
+
+  def setFeatureFlag(name: FeatureFlagName, enabled: Boolean): Future[Boolean] =
+    collection
+      .replaceOne(
+        filter = equal("name", name),
+        replacement = FeatureFlag(name, enabled, name.description),
+        options = ReplaceOptions().upsert(true)
+      )
+      .map(_.wasAcknowledged())
+      .toSingle()
+      .toFuture()
+
+  def setFeatureFlags(flags: Map[FeatureFlagName, Boolean]): Future[Unit] = {
+    val featureFlags = flags.map { case (flag, status) =>
+      FeatureFlag(flag, status, flag.description)
+    }.toList
+    withSessionAndTransaction(session =>
+      for {
+        _ <- collection.deleteMany(session, filter = in("name", flags.keys.toSeq: _*)).toFuture()
+        _ <- collection.insertMany(session, featureFlags).toFuture()
+      } yield ()
+    )
+  }
+}

--- a/app/services/AgentClientAuthorisationService.scala
+++ b/app/services/AgentClientAuthorisationService.scala
@@ -39,14 +39,13 @@ class AgentClientAuthorisationService @Inject() (
   def getAgentClientStatus(implicit hc: HeaderCarrier, ec: ExecutionContext, request: Request[_]): Future[Boolean] =
     if (agentClientAuthorisationEnabled) {
       agentClientAuthorisationConnector.getAgentClientStatus
-        .bimap(
+        .fold(
           _ => false,
           {
             case AgentClientStatus(false, false, false) => false
             case _                                      => true
           }
         )
-        .merge
         .recover {
           case FutureEarlyTimeout   =>
             logger.error(FutureEarlyTimeout.getMessage)

--- a/app/services/BreathingSpaceService.scala
+++ b/app/services/BreathingSpaceService.scala
@@ -41,11 +41,10 @@ class BreathingSpaceService @Inject() (
         case Some(nino) =>
           breathingSpaceConnector
             .getBreathingSpaceIndicator(nino)
-            .bimap(
+            .fold(
               errorResponse => breathingSpaceIndicatorResponseForErrorResponse(errorResponse),
               breathingSpaceIndicator => BreathingSpaceIndicatorResponse.fromBoolean(breathingSpaceIndicator)
             )
-            .merge
             .recover { case _ => BreathingSpaceIndicatorResponse.StatusUnknown }
         case _          => Future.successful(BreathingSpaceIndicatorResponse.StatusUnknown)
       }

--- a/app/services/SeissService.scala
+++ b/app/services/SeissService.scala
@@ -33,7 +33,7 @@ class SeissService @Inject() (seissConnector: SeissConnector, appConfig: ConfigD
     if (appConfig.isSeissTileEnabled) {
       saUserType match {
         case user: SelfAssessmentUser =>
-          seissConnector.getClaims(user.saUtr.utr).bimap(_ => false, claims => claims.nonEmpty).merge
+          seissConnector.getClaims(user.saUtr.utr).fold(_ => false, claims => claims.nonEmpty)
         case _                        => Future.successful(false)
       }
     } else {

--- a/app/services/TaxCreditsService.scala
+++ b/app/services/TaxCreditsService.scala
@@ -31,11 +31,13 @@ class TaxCreditsService @Inject() (taxCreditsConnector: TaxCreditsConnector)(imp
     if (nino.isEmpty) {
       Future.successful(Some(false))
     } else {
-      taxCreditsConnector.checkForTaxCredits(nino.get) bimap (
-        error => if (error.statusCode == NOT_FOUND) Some(false) else None,
-        result => {
-          if (result.status == OK) Some(true) else Some(false)
-        }
-      )
-    }.merge
+      taxCreditsConnector
+        .checkForTaxCredits(nino.get)
+        .fold(
+          error => if (error.statusCode == NOT_FOUND) Some(false) else None,
+          result =>
+            if (result.status == OK) Some(true)
+            else Some(false)
+        )
+    }
 }

--- a/app/services/admin/FeatureFlagService.scala
+++ b/app/services/admin/FeatureFlagService.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.admin
+
+import config.ConfigDecorator
+import models.admin.{FeatureFlag, FeatureFlagName}
+import repositories.admin.FeatureFlagRepository
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.duration.{Duration, FiniteDuration, SECONDS => Seconds}
+import scala.concurrent.{ExecutionContext, Future}
+import play.api.cache.AsyncCacheApi
+
+@Singleton
+class FeatureFlagService @Inject() (
+  configDecorator: ConfigDecorator,
+  featureFlagRepository: FeatureFlagRepository,
+  cache: AsyncCacheApi
+)(implicit
+  ec: ExecutionContext
+) {
+  val cacheValidFor: FiniteDuration   =
+    Duration(configDecorator.ehCacheTtlInSeconds, Seconds)
+  private val allFeatureFlagsCacheKey = "*$*$allFeatureFlags*$*$"
+
+  def set(flagName: FeatureFlagName, enabled: Boolean): Future[Boolean] =
+    for {
+      _      <- cache.remove(flagName.toString)
+      _      <- cache.remove(allFeatureFlagsCacheKey)
+      result <- featureFlagRepository.setFeatureFlag(flagName, enabled)
+      //blocking thread to let time to other containers to update their cache
+      _      <- Future.successful(Thread.sleep(configDecorator.ehCacheTtlInSeconds * 1000))
+    } yield result
+
+  def get(flagName: FeatureFlagName): Future[FeatureFlag] =
+    cache.getOrElseUpdate(flagName.toString, cacheValidFor) {
+      featureFlagRepository
+        .getFeatureFlag(flagName)
+        .map(_.getOrElse(FeatureFlag(flagName, false)))
+    }
+
+  def getAll: Future[List[FeatureFlag]] =
+    cache.getOrElseUpdate(allFeatureFlagsCacheKey, cacheValidFor) {
+      featureFlagRepository.getAllFeatureFlags.map { mongoFlags =>
+        FeatureFlagName.allFeatureFlags
+          .foldLeft(mongoFlags) { (featureFlags, missingFlag) =>
+            if (featureFlags.map(_.name).contains(missingFlag))
+              featureFlags
+            else
+              FeatureFlag(missingFlag, false) :: featureFlags
+          }
+          .reverse
+      }
+    }
+
+  def setAll(flags: Map[FeatureFlagName, Boolean]): Future[Unit] =
+    Future
+      .sequence(flags.keys.map(flag => cache.remove(flag.toString)))
+      .flatMap { _ =>
+        cache.remove(allFeatureFlagsCacheKey)
+        featureFlagRepository.setFeatureFlags(flags)
+      }
+      .map { _ =>
+        //blocking thread to let time to other containers to update their cache
+        Thread.sleep(configDecorator.ehCacheTtlInSeconds * 1000)
+        ()
+      }
+
+}

--- a/app/util/AuditServiceTools.scala
+++ b/app/util/AuditServiceTools.scala
@@ -19,6 +19,7 @@ package util
 import controllers.auth.requests.UserRequest
 import models.{PersonDetails, SelfAssessmentUser}
 import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames}
+import uk.gov.hmrc.internalauth.client.{AuthenticatedRequest, Retrieval}
 import uk.gov.hmrc.play.audit.model.DataEvent
 
 object AuditServiceTools {

--- a/build.sbt
+++ b/build.sbt
@@ -49,7 +49,7 @@ lazy val microservice = Project(appName, file("."))
     PlayKeys.playDefaultPort := 9232,
     scalafmtOnCompile := true,
     majorVersion := 1,
-    scalacOptions += "-P:silencer:pathFilters=views;routes",
+    scalacOptions ++= Seq("-P:silencer:pathFilters=views;routes", "-Ypartial-unification"),
     libraryDependencies ++= Seq(
       compilerPlugin("com.github.ghik" % "silencer-plugin" % silencerVersion cross CrossVersion.full),
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
@@ -57,7 +57,8 @@ lazy val microservice = Project(appName, file("."))
     routesImport ++= Seq(
       "uk.gov.hmrc.play.bootstrap.binders._",
       "controllers.bindable._",
-      "uk.gov.hmrc.play.binders._"
+      "uk.gov.hmrc.play.binders._",
+      "models.admin._"
     ),
     TwirlKeys.templateImports ++= Seq(
       "models._",

--- a/conf/admin.routes
+++ b/conf/admin.routes
@@ -1,0 +1,6 @@
+GET        /metrics                         com.kenshoo.play.metrics.MetricsController.metrics
++nocsrf
+PUT        /featureFlags/:flagName          controllers.admin.FeatureFlagsAdminController.put(flagName: FeatureFlagName)
++nocsrf
+PUT        /featureFlags          controllers.admin.FeatureFlagsAdminController.putAll
+GET        /featureFlags          controllers.admin.FeatureFlagsAdminController.get

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -43,6 +43,8 @@ play.filters.enabled += "uk.gov.hmrc.play.bootstrap.frontend.filters.SessionIdFi
 
 play.modules.enabled += "config.HmrcModule"
 
+play.modules.enabled += "uk.gov.hmrc.internalauth.client.modules.InternalAuthModule"
+
 play.http.router = prod.Routes
 
 play.http.errorHandler = "error.LocalErrorHandler"
@@ -100,6 +102,12 @@ ptaSession {
 
 tracking-consent-frontend {
   gtm.container = "c"
+}
+
+ehCache {
+  # Do not use a long cache time.
+  # During a toggle change the cache is invalidated only in the current container.
+  ttlInSeconds = 5
 }
 
 microservice {
@@ -228,6 +236,12 @@ microservice {
       host = localhost
       port = 9238
     }
+
+    internal-auth {
+      resource-type = "ddcn-live-admin-frontend"
+      host = localhost
+      port = 8470
+    }
   }
 }
 
@@ -321,9 +335,6 @@ external-url {
 }
 
 feature {
-  address-change-tax-credits-question {
-    enabled = true
-  }
   update-international-address-form {
     enabled = true
   }
@@ -349,9 +360,6 @@ feature {
     enabled = true
   }
 
-  national-insurance-tile {
-    enabled = true
-  }
   tax-components {
     enabled = true
   }
@@ -400,7 +408,5 @@ feature {
 
 feature.session-cache.ttl = 15
 feature.ur-link.url = null
-feature.taxcalc.enabled = true
-feature.national-insurance-tile.enabled	= true
 feature.single-account-enrolment.enabled = true
 contact-frontend.serviceId="PTA"

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -89,8 +89,7 @@ GET         /personal-account/preferences                                       
 
 GET         /personal-account/assets/*file                                             controllers.AssetsController.versioned(path="/public", file: Asset)
 
-GET         /admin/metrics                                                             com.kenshoo.play.metrics.MetricsController.metrics
-
+->         /admin                                                                      admin.Routes
 ->          /                                                                          health.Routes
 ->          /personal-account/hmrc-frontend                                            hmrcfrontend.Routes
 ->          /personal-account/pta-frontend                                             ptafrontend.Routes

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -1,0 +1,16 @@
+# IF THE MICRO-SERVICE DOES NOT NEED ANY TEST-ONLY END-POINTS (ALWAYS PREFERRED) DELETE THIS FILE.
+
+# !!!WARNING!!! This file MUST NOT be referenced in the "application.conf" file to avoid risk of rolling test routes in the production environment.
+# If you need test routes when running tests in CI make sure that the profile for this micro-service (used by service-manager) defines this router as parameter.
+# To do so add the following line to the micro-service profile: "-Dapplication.router=testOnlyDoNotUseInAppConf.Routes"
+# To start the micro-service locally using the test routes run the following command: "sbt run -Dapplication.router=testOnlyDoNotUseInAppConf.Routes" 
+
+# Any test-only end-point should be defined here.
+# !!!WARNING!!! Every route defined in this file MUST be prefixed with "/test-only/". This is because NGINX is blocking every uri containing the string "test-only" in production.
+# Failing to follow this rule may result in test routes deployed in production.
+
+# Add all the application routes to the prod.routes file
+
+->         /                          prod.Routes
+
+PUT /pertax-frontend/test-only/setFlag/:flagName/:isEnabled  controllers.testOnly.FeatureFlagsController.setFlag(flagName: FeatureFlagName, isEnabled: Boolean)

--- a/it/testUtils/FakeAsyncCacheApi.scala
+++ b/it/testUtils/FakeAsyncCacheApi.scala
@@ -1,0 +1,49 @@
+package testUtils
+
+import akka.Done
+import com.google.inject.Inject
+import net.sf.ehcache.Element
+import play.api.cache.AsyncCacheApi
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+
+class FakeAsyncCacheApi @Inject() ()(implicit ec: ExecutionContext) extends AsyncCacheApi {
+
+  val cache = scala.collection.mutable.Map[String, Element]()
+
+  def set(key: String, value: Any, expiration: Duration): Future[Done] = Future {
+    val element = new Element(key, value)
+
+    if (expiration.isFinite()) {
+      element.setTimeToLive(expiration.toSeconds.toInt)
+    } else {
+      element.setEternal(true)
+    }
+
+    cache.put(key, element)
+    Done
+  }
+
+  def remove(key: String): Future[Done] = Future {
+    cache -= key
+    Done
+  }
+
+  def get[T: ClassTag](key: String): Future[Option[T]] = Future {
+    cache.get(key).map(_.getObjectValue).asInstanceOf[Option[T]]
+  }
+
+  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] =
+    get[A](key).flatMap {
+      case Some(value) => Future.successful(value)
+      case None        => orElse.flatMap(value => set(key, value, expiration).map(_ => value))
+    }
+
+  def removeAll(): Future[Done] = Future {
+    cache.clear()
+    Done
+  }
+
+}

--- a/it/testUtils/InMemoryCache.scala
+++ b/it/testUtils/InMemoryCache.scala
@@ -1,0 +1,49 @@
+package testUtils
+
+import akka.Done
+import com.google.inject.Inject
+import net.sf.ehcache.Element
+import play.api.cache.AsyncCacheApi
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
+
+class InMemoryCache @Inject() ()(implicit ec: ExecutionContext) extends AsyncCacheApi {
+
+  val cache = scala.collection.mutable.Map[String, Element]()
+
+  def remove(key: String): Future[Done] = Future {
+    cache -= key
+    Done
+  }
+
+  def getOrElseUpdate[A: ClassTag](key: String, expiration: Duration)(orElse: => Future[A]): Future[A] =
+    get[A](key).flatMap {
+      case Some(value) => Future.successful(value)
+      case None        => orElse.flatMap(value => set(key, value, expiration).map(_ => value))
+    }
+
+  def set(key: String, value: Any, expiration: Duration): Future[Done] = Future {
+    val element = new Element(key, value)
+
+    if (expiration.isFinite()) {
+      element.setTimeToLive(expiration.toSeconds.toInt)
+    } else {
+      element.setEternal(true)
+    }
+
+    cache.put(key, element)
+    Done
+  }
+
+  def get[T: ClassTag](key: String): Future[Option[T]] = Future {
+    cache.get(key).map(_.getObjectValue).asInstanceOf[Option[T]]
+  }
+
+  def removeAll(): Future[Done] = Future {
+    cache.clear()
+    Done
+  }
+
+}

--- a/it/testUtils/IntegrationSpec.scala
+++ b/it/testUtils/IntegrationSpec.scala
@@ -1,15 +1,36 @@
 package testUtils
 
+import akka.Done
 import com.github.tomakehurst.wiremock.client.WireMock._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api
+import play.api.cache.AsyncCacheApi
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.domain.Generator
 
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
+
 trait IntegrationSpec extends AnyWordSpec with GuiceOneAppPerSuite with WireMockHelper with ScalaFutures with Matchers {
+
+  val mockCacheApi: AsyncCacheApi = new AsyncCacheApi {
+    override def set(key: String, value: Any, expiration: Duration): Future[Done] = Future.successful(Done)
+
+    override def remove(key: String): Future[Done] = Future.successful(Done)
+
+    override def getOrElseUpdate[A](key: String, expiration: Duration)(orElse: => Future[A])(implicit
+      evidence$1: ClassTag[A]
+    ): Future[A] = orElse
+
+    override def get[T](key: String)(implicit evidence$2: ClassTag[T]): Future[Option[T]] = Future.successful(None)
+
+    override def removeAll(): Future[Done] = Future.successful(Done)
+  }
 
   implicit override val patienceConfig = PatienceConfig(scaled(Span(15, Seconds)), scaled(Span(100, Millis)))
 
@@ -71,6 +92,9 @@ trait IntegrationSpec extends AnyWordSpec with GuiceOneAppPerSuite with WireMock
 
   protected def localGuiceApplicationBuilder(): GuiceApplicationBuilder =
     GuiceApplicationBuilder()
+      .overrides(
+        api.inject.bind[AsyncCacheApi].toInstance(mockCacheApi)
+      )
       .configure(
         "microservice.services.citizen-details.port"            -> server.port(),
         "microservice.services.auth.port"                       -> server.port(),
@@ -85,5 +109,6 @@ trait IntegrationSpec extends AnyWordSpec with GuiceOneAppPerSuite with WireMock
     server.stubFor(post(urlEqualTo("/auth/authorise")).willReturn(ok(authResponse)))
     server.stubFor(get(urlEqualTo(s"/citizen-details/nino/$generatedNino")).willReturn(ok(citizenResponse)))
     server.stubFor(get(urlMatching("/messages/count.*")).willReturn(ok("{}")))
+
   }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,10 +1,12 @@
 import play.core.PlayVersion.current
 import play.sbt.PlayImport._
 import sbt._
+import play.sbt.PlayImport.ehcache
 
 object AppDependencies {
 
   private val playVersion = "play-28"
+  private val hmrcMongoVersion = "0.73.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,
@@ -15,25 +17,27 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "tax-year"                         % "3.0.0",
     "uk.gov.hmrc"       %% "time"                             % "3.19.0",
     "uk.gov.hmrc"       %% "domain"                           % s"8.0.0-$playVersion",
-    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"         % "0.68.0",
-    "io.lemonlabs"      %% "scala-uri"                        % "2.2.3",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"               % s"3.32.0-play-28",
+    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-$playVersion"         % hmrcMongoVersion,
+    "io.lemonlabs"      %% "scala-uri"                        % "4.0.2",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"               % s"3.32.0-$playVersion",
     "uk.gov.hmrc"       %% "play-frontend-pta"                % "0.3.0",
-    "org.jsoup"          % "jsoup"                            % "1.15.1",
+    "org.jsoup"          % "jsoup"                            % "1.15.3",
     "uk.gov.hmrc"       %% "reactive-circuit-breaker"         % "3.5.0",
-    "org.typelevel"     %% "cats-core"                        % "2.6.1"
+    "org.typelevel"     %% "cats-core"                        % "2.8.0",
+    "uk.gov.hmrc"       %% s"internal-auth-client-$playVersion" % "1.2.0",
+    ehcache
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.scalatest"          %% "scalatest"                     % "3.2.8",
+    "org.scalatest"          %% "scalatest"                     % "3.2.14",
     "com.typesafe.play"      %% "play-test"                     % current,
-    "org.scalatestplus.play" %% "scalatestplus-play"            % "4.0.3",
-    "uk.gov.hmrc.mongo"      %% s"hmrc-mongo-test-$playVersion" % "0.68.0",
-    "org.scalatestplus"      %% "mockito-3-4"                   % "3.2.3.0",
-    "org.mockito"             % "mockito-core"                  % "3.6.28",
-    "org.scalacheck"         %% "scalacheck"                    % "1.15.1",
+    "org.scalatestplus.play" %% "scalatestplus-play"            % "5.1.0",
+    "uk.gov.hmrc.mongo"      %% s"hmrc-mongo-test-$playVersion" % hmrcMongoVersion,
+    "org.scalatestplus"      %% "mockito-3-4"                   % "3.2.10.0",
+    "org.mockito"             % "mockito-core"                  % "4.8.0",
+    "org.scalacheck"         %% "scalacheck"                    % "1.17.0",
     "com.github.tomakehurst"  % "wiremock-standalone"           % "2.27.2",
-    "com.vladsch.flexmark"    % "flexmark-all"                  % "0.36.8"
+    "com.vladsch.flexmark"    % "flexmark-all"                  % "0.62.0"
   ).map(_ % "test,it")
 
   val all: Seq[ModuleID]  = compile ++ test

--- a/test/controllers/address/TaxCreditsChoiceControllerSpec.scala
+++ b/test/controllers/address/TaxCreditsChoiceControllerSpec.scala
@@ -17,48 +17,56 @@
 package controllers.address
 
 import controllers.controllershelpers.AddressJourneyCachingHelper
-import models.dto.AddressPageVisitedDto
-import models.{NonFilerSelfAssessmentUser, PersonDetails, SelfAssessmentUserType}
+import models.admin.{AddressTaxCreditsBrokerCallToggle, FeatureFlag, TaxcalcToggle}
+import models.dto.{AddressPageVisitedDto, TaxCreditsChoiceDto}
+import models.{CacheIdentifier, NonFilerSelfAssessmentUser, PersonDetails, SelfAssessmentUserType}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, times, verify, when}
+import org.mockito.Mockito.{reset, spy, times, verify, when}
 import play.api.Application
 import play.api.http.Status.SEE_OTHER
 import play.api.inject.bind
 import play.api.libs.json.Json
+import play.api.mvc.Results.Ok
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import services.admin.FeatureFlagService
 import services.{LocalSessionCache, TaxCreditsService}
 import testUtils.BaseSpec
 import testUtils.Fixtures.buildPersonDetailsCorrespondenceAddress
-import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.{HeaderNames, HttpResponse}
 import uk.gov.hmrc.http.cache.client.CacheMap
+import uk.gov.hmrc.play.audit.model.DataEvent
 
 import scala.concurrent.Future
 
 class TaxCreditsChoiceControllerSpec extends BaseSpec {
 
-  val mockTaxCreditsService: TaxCreditsService = mock[TaxCreditsService]
-  val mockLocalSessionCache: LocalSessionCache = mock[LocalSessionCache]
+  val mockTaxCreditsService: TaxCreditsService   = mock[TaxCreditsService]
+  val mockLocalSessionCache: LocalSessionCache   = mock[LocalSessionCache]
+  val mockFeatureFlagService: FeatureFlagService = mock[FeatureFlagService]
+  val mockAddressJourneyCachingHelper            = mock[AddressJourneyCachingHelper]
 
   override implicit lazy val app: Application = localGuiceApplicationBuilder(saUserType, personDetailsForRequest)
     .overrides(
       bind[LocalSessionCache].toInstance(mockLocalSessionCache),
-      bind[TaxCreditsService].toInstance(mockTaxCreditsService)
-    )
-    .configure(
-      "feature.address-change-tax-credits-question.enabled" -> true
+      bind[TaxCreditsService].toInstance(mockTaxCreditsService),
+      bind[FeatureFlagService].toInstance(mockFeatureFlagService),
+      bind[AddressJourneyCachingHelper].toInstance(mockAddressJourneyCachingHelper)
     )
     .build()
 
   override def beforeEach(): Unit = {
-    reset(mockLocalSessionCache, mockTaxCreditsService)
+    reset(mockLocalSessionCache, mockTaxCreditsService, mockFeatureFlagService, mockAddressJourneyCachingHelper)
     super.beforeEach()
   }
 
-  def currentRequest[A]: Request[A]                  = FakeRequest().asInstanceOf[Request[A]]
+  def currentRequest[A]: Request[A] = FakeRequest().asInstanceOf[Request[A]]
+
   def personDetailsForRequest: Option[PersonDetails] = Some(buildPersonDetailsCorrespondenceAddress)
-  def saUserType: SelfAssessmentUserType             = NonFilerSelfAssessmentUser
+
+  def saUserType: SelfAssessmentUserType = NonFilerSelfAssessmentUser
 
   val sessionCacheResponse: Option[CacheMap] =
     Some(CacheMap("id", Map("addressPageVisitedDto" -> Json.toJson(AddressPageVisitedDto(true)))))
@@ -72,143 +80,119 @@ class TaxCreditsChoiceControllerSpec extends BaseSpec {
 
   val controller = injected[TaxCreditsChoiceController]
 
-  "onPageLoad" must {
+  "onPageLoad" when {
+    "Tax-credit-broker call is used" must {
+      "return SEE OTHER to `do-you-live-in-the-uk` if the user does not receives tax credits" in {
+        val arg = ArgumentCaptor.forClass(classOf[Result])
 
-    "return OK if there is an entry in the cache to say the user previously visited the 'personal details' page" in {
-      when(mockLocalSessionCache.fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())) thenReturn {
-        Future.successful(Some(AddressPageVisitedDto(true)))
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(AddressTaxCreditsBrokerCallToggle)))
+          .thenReturn(Future.successful(FeatureFlag(AddressTaxCreditsBrokerCallToggle, true)))
+        when(mockTaxCreditsService.checkForTaxCredits(any())(any())).thenReturn(Future.successful(Some(false)))
+        when(mockAddressJourneyCachingHelper.enforceDisplayAddressPageVisited(any())(any()))
+          .thenReturn(Future.successful(Ok("Fake Page")))
+
+        val result = controller.onPageLoad(currentRequest)
+
+        status(result) mustBe OK
+        verify(mockFeatureFlagService, times(1)).get(any())
+        verify(mockAddressJourneyCachingHelper, times(1)).enforceDisplayAddressPageVisited(arg.capture)(any())
+        verify(mockTaxCreditsService, times(1)).checkForTaxCredits(any())(any())
+        val argCaptorValue: Result = arg.getValue
+        argCaptorValue.header.status mustBe SEE_OTHER
+        redirectLocation(Future.successful(argCaptorValue)) mustBe Some(
+          "/personal-account/your-address/residential/do-you-live-in-the-uk"
+        )
       }
 
-      val result = controller.onPageLoad(currentRequest)
+      "return SEE_OTHER to `tax-credits-service/personal/change-address` if the user receives tax credits" in {
+        val arg = ArgumentCaptor.forClass(classOf[Result])
 
-      status(result) mustBe OK
-      verify(mockLocalSessionCache, times(1)).fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(AddressTaxCreditsBrokerCallToggle)))
+          .thenReturn(Future.successful(FeatureFlag(AddressTaxCreditsBrokerCallToggle, true)))
+        when(mockTaxCreditsService.checkForTaxCredits(any())(any())).thenReturn(Future.successful(Some(true)))
+        when(mockAddressJourneyCachingHelper.enforceDisplayAddressPageVisited(any())(any()))
+          .thenReturn(Future.successful(Ok("Fake Page")))
+
+        val controller = app.injector.instanceOf[TaxCreditsChoiceController]
+
+        val result = controller.onPageLoad(currentRequest)
+
+        status(result) mustBe OK
+        verify(mockFeatureFlagService, times(1)).get(any())
+        verify(mockAddressJourneyCachingHelper, times(1)).enforceDisplayAddressPageVisited(arg.capture)(any())
+        verify(mockTaxCreditsService, times(1)).checkForTaxCredits(any())(any())
+        val argCaptorValue: Result = arg.getValue
+        argCaptorValue.header.status mustBe SEE_OTHER
+        redirectLocation(Future.successful(argCaptorValue)).get must include(
+          "tax-credits-service/personal/change-address"
+        )
+      }
+
+      "return INTERNAL_SERVER_ERROR and no redirect URL if the tax credits service returns None" in {
+        val arg = ArgumentCaptor.forClass(classOf[Result])
+
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(AddressTaxCreditsBrokerCallToggle)))
+          .thenReturn(Future.successful(FeatureFlag(AddressTaxCreditsBrokerCallToggle, true)))
+        when(mockTaxCreditsService.checkForTaxCredits(any())(any())).thenReturn(Future.successful(None))
+        when(mockAddressJourneyCachingHelper.enforceDisplayAddressPageVisited(any())(any()))
+          .thenReturn(Future.successful(Ok("Fake Page")))
+
+        val controller = app.injector.instanceOf[TaxCreditsChoiceController]
+
+        val result = controller.onPageLoad(currentRequest)
+
+        status(result) mustBe OK
+        verify(mockFeatureFlagService, times(1)).get(any())
+        verify(mockAddressJourneyCachingHelper, times(1)).enforceDisplayAddressPageVisited(arg.capture)(any())
+        verify(mockTaxCreditsService, times(1)).checkForTaxCredits(any())(any())
+        val argCaptorValue: Result = arg.getValue
+        argCaptorValue.header.status mustBe INTERNAL_SERVER_ERROR
+      }
     }
 
-    "return SEE_OTHER and the correct redirect if the user has tax credits" in {
-      implicit lazy val app: Application = localGuiceApplicationBuilder(saUserType, personDetailsForRequest)
-        .overrides(
-          bind[LocalSessionCache].toInstance(mockLocalSessionCache),
-          bind[TaxCreditsService].toInstance(mockTaxCreditsService)
-        )
-        .configure(
-          "feature.address-change-tax-credits-question.enabled" -> false
-        )
-        .build()
+    "Tax-credit-broker call is not used and the question ask to the user" must {
+      "return SEE_OTHER and the correct redirect if the user has tax credits" in {
+        val arg = ArgumentCaptor.forClass(classOf[Result])
 
-      val controller = app.injector.instanceOf[TaxCreditsChoiceController]
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(AddressTaxCreditsBrokerCallToggle)))
+          .thenReturn(Future.successful(FeatureFlag(AddressTaxCreditsBrokerCallToggle, false)))
+        when(mockTaxCreditsService.checkForTaxCredits(any())(any())).thenReturn(null)
+        when(mockAddressJourneyCachingHelper.enforceDisplayAddressPageVisited(any())(any()))
+          .thenReturn(Future.successful(Ok("Fake Page")))
 
-      when(mockTaxCreditsService.checkForTaxCredits(any())(any())).thenReturn(Future.successful(Some(true)))
-      when(mockLocalSessionCache.fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())) thenReturn {
-        Future.successful(Some(AddressPageVisitedDto(true)))
+        val controller = app.injector.instanceOf[TaxCreditsChoiceController]
+
+        val result = controller.onPageLoad(currentRequest)
+
+        status(result) mustBe OK
+        verify(mockFeatureFlagService, times(1)).get(any())
+        verify(mockAddressJourneyCachingHelper, times(1)).enforceDisplayAddressPageVisited(arg.capture)(any())
+        verify(mockTaxCreditsService, times(0)).checkForTaxCredits(any())(any())
+        val argCaptorValue: Result = arg.getValue
+        argCaptorValue.header.status mustBe OK
+        contentAsString(Future.successful(argCaptorValue)) must include("Do you get tax credits?")
       }
-
-      val result = controller.onPageLoad(currentRequest)
-
-      status(result) mustBe SEE_OTHER
-
-      redirectLocation(result) mustBe Some("http://localhost:9362/tax-credits-service/personal/change-address")
-
-      verify(mockLocalSessionCache, times(1)).fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())
-    }
-
-    "return SEE_OTHER and the correct redirect if the user hasn't got tax credits" in {
-      implicit lazy val app: Application = localGuiceApplicationBuilder(saUserType, personDetailsForRequest)
-        .overrides(
-          bind[LocalSessionCache].toInstance(mockLocalSessionCache),
-          bind[TaxCreditsService].toInstance(mockTaxCreditsService)
-        )
-        .configure(
-          "feature.address-change-tax-credits-question.enabled" -> false
-        )
-        .build()
-
-      val controller = app.injector.instanceOf[TaxCreditsChoiceController]
-
-      when(mockTaxCreditsService.checkForTaxCredits(any())(any())).thenReturn(Future.successful(Some(false)))
-      when(mockLocalSessionCache.fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())) thenReturn {
-        Future.successful(Some(AddressPageVisitedDto(true)))
-      }
-
-      val result = controller.onPageLoad(currentRequest)
-
-      status(result) mustBe SEE_OTHER
-
-      redirectLocation(result) mustBe Some("/personal-account/your-address/residential/do-you-live-in-the-uk")
-
-      verify(mockLocalSessionCache, times(1)).fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())
-    }
-
-    "return INTERNAL_SERVER_ERROR and no redirect URL if the service returns None" in {
-      implicit lazy val app: Application = localGuiceApplicationBuilder(saUserType, personDetailsForRequest)
-        .overrides(
-          bind[LocalSessionCache].toInstance(mockLocalSessionCache),
-          bind[TaxCreditsService].toInstance(mockTaxCreditsService)
-        )
-        .configure(
-          "feature.address-change-tax-credits-question.enabled" -> false
-        )
-        .build()
-
-      val controller = app.injector.instanceOf[TaxCreditsChoiceController]
-
-      when(mockTaxCreditsService.checkForTaxCredits(any())(any())).thenReturn(Future.successful(None))
-      when(mockLocalSessionCache.fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())) thenReturn {
-        Future.successful(Some(AddressPageVisitedDto(true)))
-      }
-
-      val result = controller.onPageLoad(currentRequest)
-
-      status(result) mustBe INTERNAL_SERVER_ERROR
-
-      redirectLocation(result) mustBe None
-
-      verify(mockLocalSessionCache, times(1)).fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())
-    }
-
-    "redirect back to the start of the journey if there is no entry in the cache to say the user previously visited the 'personal details' page" in {
-      when(mockLocalSessionCache.fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())) thenReturn {
-        Future.successful(None)
-      }
-
-      val result = controller.onPageLoad(currentRequest)
-
-      status(result) mustBe SEE_OTHER
-      redirectLocation(result) mustBe Some("/personal-account/profile-and-settings")
-      verify(mockLocalSessionCache, times(1)).fetchAndGetEntry[AddressPageVisitedDto](any())(any(), any(), any())
     }
   }
 
   "onSubmit" must {
-
     "redirect to expected tax credits page when supplied with value = Yes (true)" in {
-      val mockAddressJourneyCachingHelper = mock[AddressJourneyCachingHelper]
-
-      implicit lazy val app: Application =
-        localGuiceApplicationBuilder(NonFilerSelfAssessmentUser, personDetailsForRequest)
-          .overrides(
-            bind[LocalSessionCache].toInstance(mockLocalSessionCache),
-            bind[TaxCreditsService].toInstance(mockTaxCreditsService),
-            bind[AddressJourneyCachingHelper].toInstance(mockAddressJourneyCachingHelper)
-          )
-          .configure(
-            "feature.address-change-tax-credits-question.enabled" -> true
-          )
-          .build()
 
       val controller = app.injector.instanceOf[TaxCreditsChoiceController]
 
+      when(mockFeatureFlagService.get(ArgumentMatchers.eq(AddressTaxCreditsBrokerCallToggle)))
+        .thenReturn(Future.successful(FeatureFlag(AddressTaxCreditsBrokerCallToggle, false)))
       when(mockLocalSessionCache.fetch()(any(), any())) thenReturn {
         Future.successful(sessionCacheResponse)
       }
-
       when(mockAddressJourneyCachingHelper.addToCache(any(), any())(any(), any())) thenReturn {
         Future.successful(CacheMap("id", Map.empty))
       }
-
       when(mockEditAddressLockRepository.insert(any(), any())) thenReturn {
         Future.successful(true)
       }
+      when(mockAddressJourneyCachingHelper.enforceDisplayAddressPageVisited(any())(any()))
+        .thenReturn(Future.successful(Ok("Page")))
 
       val result =
         controller.onSubmit(
@@ -221,30 +205,18 @@ class TaxCreditsChoiceControllerSpec extends BaseSpec {
     }
 
     "redirect to InternationalAddressChoice page when supplied with value = No (false)" in {
-      val mockAddressJourneyCachingHelper = mock[AddressJourneyCachingHelper]
-
-      implicit lazy val app: Application =
-        localGuiceApplicationBuilder(NonFilerSelfAssessmentUser, personDetailsForRequest)
-          .overrides(
-            bind[LocalSessionCache].toInstance(mockLocalSessionCache),
-            bind[TaxCreditsService].toInstance(mockTaxCreditsService),
-            bind[AddressJourneyCachingHelper].toInstance(mockAddressJourneyCachingHelper)
-          )
-          .configure(
-            "feature.address-change-tax-credits-question.enabled" -> true
-          )
-          .build()
-
       val controller = app.injector.instanceOf[TaxCreditsChoiceController]
 
+      when(mockFeatureFlagService.get(ArgumentMatchers.eq(AddressTaxCreditsBrokerCallToggle)))
+        .thenReturn(Future.successful(FeatureFlag(AddressTaxCreditsBrokerCallToggle, false)))
       when(mockLocalSessionCache.fetch()(any(), any())) thenReturn {
         Future.successful(sessionCacheResponse)
       }
-
-      when(mockAddressJourneyCachingHelper.addToCache(any(), any())(any(), any())) thenReturn {
+      when(
+        mockAddressJourneyCachingHelper.addToCache(any(), any())(any(), any())
+      ) thenReturn {
         Future.successful(CacheMap("id", Map.empty))
       }
-
       when(mockEditAddressLockRepository.insert(any(), any())) thenReturn {
         Future.successful(true)
       }
@@ -262,11 +234,12 @@ class TaxCreditsChoiceControllerSpec extends BaseSpec {
       when(mockLocalSessionCache.fetch()(any(), any())) thenReturn {
         Future.successful(sessionCacheResponse)
       }
+      when(mockFeatureFlagService.get(ArgumentMatchers.eq(AddressTaxCreditsBrokerCallToggle)))
+        .thenReturn(Future.successful(FeatureFlag(AddressTaxCreditsBrokerCallToggle, false)))
 
       val result = controller.onSubmit(FakeRequest())
 
       status(result) mustBe BAD_REQUEST
     }
   }
-
 }

--- a/test/controllers/admin/FeatureFlagsAdminControllerSpec.scala
+++ b/test/controllers/admin/FeatureFlagsAdminControllerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.admin
+
+import controllers.auth.InternalAuthAction
+import config.ConfigDecorator
+import org.mockito.ArgumentMatchers.any
+import play.api.http.Status
+import play.api.http.Status._
+import play.api.libs.json.{JsBoolean, Json}
+import play.api.mvc.ControllerComponents
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{await, contentAsString, defaultAwaitTimeout, status}
+import services.admin.FeatureFlagService
+import testUtils.{BaseSpec, Fixtures}
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import uk.gov.hmrc.internalauth.client.Predicate.Permission
+import uk.gov.hmrc.internalauth.client.test.{BackendAuthComponentsStub, StubBehaviour}
+import models.admin.{AddressTaxCreditsBrokerCallToggle, FeatureFlag, TaxcalcToggle}
+import org.mockito.Mockito.{reset, when}
+import play.api.Configuration
+import play.api.i18n.Langs
+import uk.gov.hmrc.internalauth.client.{IAAction, Resource, ResourceLocation, ResourceType, Retrieval}
+import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import scala.concurrent.Future
+
+class FeatureFlagsAdminControllerSpec extends BaseSpec {
+  implicit val cc        = injected[ControllerComponents]
+  val nino               = Fixtures.fakeNino
+  val expectedPermission =
+    Permission(
+      resource = Resource(
+        resourceType = ResourceType("ddcn-live-admin-frontend"),
+        resourceLocation = ResourceLocation("*")
+      ),
+      action = IAAction("ADMIN")
+    )
+
+  lazy val mockStubBehaviour      = mock[StubBehaviour]
+  lazy val mockFeatureFlagService = mock[FeatureFlagService]
+  lazy val fakeInternalAuthAction =
+    new InternalAuthAction(
+      new ConfigDecorator(injected[Configuration], injected[Langs], injected[ServicesConfig]),
+      BackendAuthComponentsStub(mockStubBehaviour)
+    )
+
+  val sut = new FeatureFlagsAdminController(fakeInternalAuthAction, mockFeatureFlagService, cc)(ec)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockStubBehaviour, mockFeatureFlagService)
+    when(mockStubBehaviour.stubAuth(Some(expectedPermission), Retrieval.username))
+      .thenReturn(Future.successful(Retrieval.Username("Test")))
+  }
+
+  "GET /get" must {
+    "returns a list of toggles" when {
+      "all is well" in {
+        when(mockFeatureFlagService.getAll).thenReturn(Future.successful(List(FeatureFlag(TaxcalcToggle, true))))
+
+        val result = sut.get(
+          FakeRequest().withHeaders("Authorization" -> "Token some-token")
+        )
+
+        status(result) mustBe OK
+        contentAsString(result) mustBe """[{"name":"taxcalc","isEnabled":true}]"""
+      }
+    }
+
+    "returns an exception" when {
+      "The user is not authorised" in {
+        reset(mockStubBehaviour)
+        when(mockStubBehaviour.stubAuth(Some(expectedPermission), Retrieval.username))
+          .thenReturn(Future.failed(UpstreamErrorResponse("Unauthorized", Status.UNAUTHORIZED)))
+
+        when(mockFeatureFlagService.getAll).thenReturn(Future.successful(List(FeatureFlag(TaxcalcToggle, true))))
+
+        val result = sut.get(
+          FakeRequest().withHeaders("Authorization" -> "Token some-token")
+        )
+
+        whenReady(result.failed) { e =>
+          e mustBe a[UpstreamErrorResponse]
+        }
+      }
+    }
+  }
+
+  "PUT /put" must {
+    "returns no content" when {
+      "all is well" in {
+        when(mockFeatureFlagService.set(any(), any())).thenReturn(Future.successful(true))
+
+        val result = sut.put(TaxcalcToggle)(
+          FakeRequest()
+            .withHeaders("Authorization" -> "Token some-token")
+            .withJsonBody(JsBoolean(true))
+        )
+
+        status(result) mustBe NO_CONTENT
+        contentAsString(result) mustBe ""
+      }
+    }
+  }
+
+  "PUT /puAll" must {
+    "returns no content" when {
+      "all is well" in {
+        when(mockFeatureFlagService.setAll(any())).thenReturn(Future.successful(()))
+
+        val result = sut.putAll(
+          FakeRequest()
+            .withHeaders("Authorization" -> "Token some-token")
+            .withJsonBody(
+              Json.toJson(List(FeatureFlag(TaxcalcToggle, true), FeatureFlag(AddressTaxCreditsBrokerCallToggle, false)))
+            )
+        )
+
+        status(result) mustBe NO_CONTENT
+      }
+    }
+
+    "returns internal server error" when {
+      "there is an error" in {
+        when(mockFeatureFlagService.setAll(any())).thenReturn(Future.failed(new RuntimeException("Random exception")))
+
+        val result = intercept[RuntimeException] {
+          await(
+            sut.putAll(
+              FakeRequest()
+                .withHeaders("Authorization" -> "Token some-token")
+                .withJsonBody(
+                  Json.toJson(
+                    List(FeatureFlag(TaxcalcToggle, true), FeatureFlag(AddressTaxCreditsBrokerCallToggle, false))
+                  )
+                )
+            )
+          )
+        }
+        result.getMessage mustBe "Random exception"
+      }
+    }
+  }
+}

--- a/test/repositories/admin/FeatureFlagRepositorySpec.scala
+++ b/test/repositories/admin/FeatureFlagRepositorySpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories.admin
+
+import models.admin.{AddressTaxCreditsBrokerCallToggle, FeatureFlag}
+import org.mongodb.scala.MongoWriteException
+import org.mongodb.scala.bson.BsonDocument
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import testUtils.{BaseSpec, FeatureFlagRepositoryUtils}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+class FeatureFlagRepositorySpec extends BaseSpec with DefaultPlayMongoRepositorySupport[FeatureFlag] {
+
+  override protected lazy val optSchema = Some(BsonDocument("""
+      { bsonType: "object"
+      , required: [ "_id", "name", "isEnabled" ]
+      , properties:
+        { _id       : { bsonType: "objectId" }
+        , name      : { bsonType: "string" }
+        , isEnabled : { bsonType: "bool" }
+        , description : { bsonType: "string" }
+        }
+      }
+    """))
+
+  override implicit lazy val app = localGuiceApplicationBuilder()
+    .configure(Map("mongodb.uri" -> mongoUri) ++ configValues)
+    .build()
+
+  lazy val repository = app.injector.instanceOf[FeatureFlagRepository]
+
+  "getFlag" must {
+    "return None if there is no record" in {
+      val result = repository.getFeatureFlag(AddressTaxCreditsBrokerCallToggle).futureValue
+
+      result mustBe None
+    }
+  }
+
+  "setFeatureFlag and getFeatureFlag" must {
+    "insert and read a record in mongo" in {
+
+      val result = (for {
+        _      <- repository.setFeatureFlag(AddressTaxCreditsBrokerCallToggle, true)
+        result <- repository.getFeatureFlag(AddressTaxCreditsBrokerCallToggle)
+      } yield result).futureValue
+
+      result mustBe Some(
+        FeatureFlag(AddressTaxCreditsBrokerCallToggle, true, AddressTaxCreditsBrokerCallToggle.description)
+      )
+
+    }
+  }
+
+  "setFeatureFlag" must {
+    "replace a record not create a new one" in {
+      val result = (for {
+        _      <- repository.setFeatureFlag(AddressTaxCreditsBrokerCallToggle, true)
+        _      <- repository.setFeatureFlag(AddressTaxCreditsBrokerCallToggle, false)
+        result <- repository.getFeatureFlag(AddressTaxCreditsBrokerCallToggle)
+      } yield result).futureValue
+
+      result mustBe Some(
+        FeatureFlag(AddressTaxCreditsBrokerCallToggle, false, AddressTaxCreditsBrokerCallToggle.description)
+      )
+
+    }
+  }
+
+  "getAllFeatureFlags" must {
+    "get a list of all the feature toggles" in {
+      lazy val adminRepositoryUtils = app.injector.instanceOf[FeatureFlagRepositoryUtils]
+
+      val allFlags: Seq[FeatureFlag] = (for {
+        _      <- adminRepositoryUtils.setFeatureFlag(AddressTaxCreditsBrokerCallToggle, true)
+        result <- repository.getAllFeatureFlags
+      } yield result).futureValue
+
+      allFlags mustBe List(
+        FeatureFlag(AddressTaxCreditsBrokerCallToggle, true, AddressTaxCreditsBrokerCallToggle.description)
+      )
+    }
+  }
+
+  "Collection" must {
+    "not allow duplicates" in {
+      lazy val adminRepositoryUtils = app.injector.instanceOf[FeatureFlagRepositoryUtils]
+
+      val result = intercept[MongoWriteException] {
+        await((for {
+          _ <- adminRepositoryUtils.insertFeatureFlag(AddressTaxCreditsBrokerCallToggle, true)
+          _ <- adminRepositoryUtils.insertFeatureFlag(AddressTaxCreditsBrokerCallToggle, false)
+        } yield true))
+      }
+      result.getCode mustBe 11000
+      result.getError.getMessage mustBe s"""E11000 duplicate key error collection: $databaseName.admin-feature-flags index: name dup key: { name: "$AddressTaxCreditsBrokerCallToggle" }"""
+    }
+  }
+}

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -18,3 +18,6 @@ play.ws.timeout.request = "1000ms"
 play.ws.timeout.connection = "500ms"
 
 feature.single-account-enrolment.enabled = true
+
+play.cache.bindCaches = ["controller-cache", "document-cache"]
+play.cache.createBoundCaches = false

--- a/test/testUtils/FeatureFlagRepositoryUtils.scala
+++ b/test/testUtils/FeatureFlagRepositoryUtils.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testUtils
+
+import models.admin.{FeatureFlag, FeatureFlagName}
+import repositories.admin.FeatureFlagRepository
+import uk.gov.hmrc.mongo.MongoComponent
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class FeatureFlagRepositoryUtils @Inject() (mongoComponent: MongoComponent)(implicit
+  ec: ExecutionContext
+) extends FeatureFlagRepository(mongoComponent)(ec) {
+
+  def insertFeatureFlag(name: FeatureFlagName, enabled: Boolean): Future[Boolean] =
+    collection
+      .insertOne(FeatureFlag(name, enabled))
+      .map(_.wasAcknowledged())
+      .toSingle()
+      .toFuture()
+}


### PR DESCRIPTION
Add the following toggles in Mongo:

New address journey with tax credits broker call
National insurance tile
taxcalc tile

Plus admin and test-only routes