### PR TITLE
DDCNL: fixed the route so it is available via *.tax.service.gov.uk

### DIFF
--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -14,3 +14,4 @@
 ->         /                          prod.Routes
 
 PUT /pertax-frontend/test-only/setFlag/:flagName/:isEnabled  controllers.testOnly.FeatureFlagsController.setFlag(flagName: FeatureFlagName, isEnabled: Boolean)
+PUT /personal-account/test-only/setFlag/:flagName/:isEnabled  controllers.testOnly.FeatureFlagsController.setFlag(flagName: FeatureFlagName, isEnabled: Boolean)


### PR DESCRIPTION
The old route is kept as it is still used locally during AT tests