### PR TITLE
Ddcnl-10786: pega / mdtp split traffic

### DIFF
--- a/app/config/ConfigDecorator.scala
+++ b/app/config/ConfigDecorator.scala
@@ -280,4 +280,7 @@ class ConfigDecorator @Inject() (
 
   val mongoEncryptionEnabled: Boolean = runModeConfiguration.get[Boolean]("mongo.encryption.enabled")
 
+  val payeToPegaRedirectList: Seq[Int] = runModeConfiguration.get[Seq[Int]]("paye.to.pega.redirect.list")
+  val payeToPegaRedirectUrl: String    = runModeConfiguration.get[String]("paye.to.pega.redirect.url")
+
 }

--- a/app/controllers/controllershelpers/HomeCardGenerator.scala
+++ b/app/controllers/controllershelpers/HomeCardGenerator.scala
@@ -87,7 +87,7 @@ class HomeCardGenerator @Inject() (
     }
 
   def getPayAsYouEarnCard(implicit request: UserRequest[?], messages: Messages): HtmlFormat.Appendable =
-    payAsYouEarnView(configDecorator, request.authNino.withoutSuffix.takeRight(2))
+    payAsYouEarnView()
 
   private def displaySACall: Call = routes.InterstitialController.displaySelfAssessment
 

--- a/app/views/cards/home/PayAsYouEarnView.scala.html
+++ b/app/views/cards/home/PayAsYouEarnView.scala.html
@@ -16,17 +16,27 @@
 
 @import tags._
 @import config.ConfigDecorator
-@this()
-@(configDecorator: ConfigDecorator, dataGroupValue: String)(implicit messages: play.api.i18n.Messages)
+@import controllers.auth.requests.UserRequest
+
+@this(configDecorator: ConfigDecorator)
+@()(implicit messages: play.api.i18n.Messages, request: UserRequest[_])
+
+@urlToPaye() = @{
+    val lastDigit = request.authNino.withoutSuffix.reverse.take(1).toInt
+    if(configDecorator.payeToPegaRedirectList.contains(lastDigit)) {
+        s"${configDecorator.payeToPegaRedirectUrl}"
+    } else {
+        s"${configDecorator.taiHost}/check-income-tax/what-do-you-want-to-do"
+    }
+}
 
 @card(
     id = Some("paye-card"),
-    url = Some(s"${configDecorator.taiHost}/check-income-tax/what-do-you-want-to-do"),
+    url = Some(urlToPaye()),
     gaAction = Some("Income"),
     gaLabel = Some("Pay As You Earn (PAYE)"),
     heading = messages("label.pay_as_you_earn_paye"),
     headingTag = "h2",
-    bodyContent = Some(Html("<p class=\"govuk-body\">" + messages("label.your_income_from_employers_and_private_pensions_") + "</p>")),
-    divAttr = Map("data-user-group" -> dataGroupValue)
+    bodyContent = Some(Html("<p class=\"govuk-body\">" + messages("label.your_income_from_employers_and_private_pensions_") + "</p>"))
 ) {
 }

--- a/app/views/cards/home/PayAsYouEarnView.scala.html
+++ b/app/views/cards/home/PayAsYouEarnView.scala.html
@@ -22,8 +22,8 @@
 @()(implicit messages: play.api.i18n.Messages, request: UserRequest[_])
 
 @urlToPaye() = @{
-    val lastDigit = request.authNino.withoutSuffix.reverse.take(1).toInt
-    if(configDecorator.payeToPegaRedirectList.contains(lastDigit)) {
+    val penultimateDigit = request.authNino.nino.charAt(6).asDigit
+    if(configDecorator.payeToPegaRedirectList.contains(penultimateDigit)) {
         s"${configDecorator.payeToPegaRedirectUrl}"
     } else {
         s"${configDecorator.taiHost}/check-income-tax/what-do-you-want-to-do"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -353,6 +353,8 @@ request-body-encryption {
     key = "l4uhRYT6/OKm9Pmf2DfdmQ=="
     previousKeys = []
 }
-
 # End of Webchat section
+
+paye.to.pega.redirect.list = []
+paye.to.pega.redirect.url = ""
 

--- a/test/controllers/controllershelpers/HomeCardGeneratorSpec.scala
+++ b/test/controllers/controllershelpers/HomeCardGeneratorSpec.scala
@@ -108,7 +108,7 @@ class HomeCardGeneratorSpec extends ViewSpec with MockitoSugar {
       lazy val cardBody =
         homeCardGenerator.getPayAsYouEarnCard
 
-      cardBody mustBe payAsYouEarn(config, "00")
+      cardBody mustBe payAsYouEarn()
     }
   }
 

--- a/test/controllers/controllershelpers/HomeCardGeneratorSpec.scala
+++ b/test/controllers/controllershelpers/HomeCardGeneratorSpec.scala
@@ -92,7 +92,7 @@ class HomeCardGeneratorSpec extends ViewSpec with MockitoSugar {
       mockTaxCalcPartialService
     )(configDecorator, ec)
 
-  private val homeCardGenerator = createHomeCardGenerator(stubConfigDecorator)
+  private lazy val homeCardGenerator = createHomeCardGenerator(stubConfigDecorator)
 
   "Calling getPayAsYouEarnCard" must {
     "return correct markup when called with with a Pertax user that is PAYE" in {

--- a/test/views/html/HomeViewSpec.scala
+++ b/test/views/html/HomeViewSpec.scala
@@ -20,13 +20,19 @@ import config.ConfigDecorator
 import controllers.auth.requests.UserRequest
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.mockito.Mockito.{reset, when}
+import play.api
+import play.api.Application
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import testUtils.UserRequestFixture.buildUserRequest
-import uk.gov.hmrc.domain.{Nino, SaUtrGenerator}
+import uk.gov.hmrc.domain.SaUtrGenerator
 import viewmodels.HomeViewModel
 import views.html.cards.home.PayAsYouEarnView
+import controllers.bindable.Origin
+import org.mockito.ArgumentMatchers.any
+import repositories.JourneyCacheRepository
 
 import scala.jdk.CollectionConverters._
 
@@ -35,7 +41,23 @@ class HomeViewSpec extends ViewSpec {
   lazy val home: HomeView             = inject[HomeView]
   lazy val payeCard: PayAsYouEarnView = inject[PayAsYouEarnView]
 
-  implicit val configDecorator: ConfigDecorator = inject[ConfigDecorator]
+  implicit val mockConfigDecorator: ConfigDecorator = mock[ConfigDecorator]
+
+  override implicit lazy val app: Application = localGuiceApplicationBuilder()
+    .overrides(
+      api.inject.bind[ConfigDecorator].toInstance(mockConfigDecorator),
+      api.inject.bind[JourneyCacheRepository].toInstance(mock[JourneyCacheRepository])
+    )
+    .build()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockConfigDecorator)
+    when(mockConfigDecorator.defaultOrigin).thenReturn(Origin("PERTAX"))
+    when(mockConfigDecorator.personalAccount).thenReturn("/personal-account")
+    when(mockConfigDecorator.getFeedbackSurveyUrl(any())).thenReturn("/feedback/url")
+
+  }
 
   val homeViewModel: HomeViewModel =
     HomeViewModel(Nil, Nil, Nil, showUserResearchBanner = true, None, breathingSpaceIndicator = true, List.empty, None)
@@ -92,6 +114,11 @@ class HomeViewSpec extends ViewSpec {
     }
 
     "show the Nps Shutter Banner when boolean is set to true" in {
+      when(mockConfigDecorator.shutterBannerParagraphCy).thenReturn("Welsh content")
+      when(mockConfigDecorator.shutterBannerParagraphEn).thenReturn(
+        "A number of services will be unavailable from 10pm on Friday 12 July to 7am Monday 15 July."
+      )
+
       implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
       val view                                                      = home(homeViewModel, shutteringMessaging = true).toString
 

--- a/test/views/html/HomeViewSpec.scala
+++ b/test/views/html/HomeViewSpec.scala
@@ -129,20 +129,5 @@ class HomeViewSpec extends ViewSpec {
       view.getElementById("alert-banner") mustBe null
     }
 
-    "have the last 2 nino numbers be rendered as an attribute on PAYE tile" in {
-      implicit val userRequest: UserRequest[AnyContentAsEmpty.type] =
-        buildUserRequest(request = FakeRequest(), authNino = Nino("AA000000C"))
-      val view                                                      = Jsoup.parse(
-        home(
-          homeViewModel.copy(
-            incomeCards = Seq(payeCard(configDecorator, "00")),
-            alertBannerContent = List(Html("something to alert"))
-          ),
-          shutteringMessaging = true
-        ).toString
-      )
-
-      view.getElementById("paye-card").attr("data-user-group") mustBe "00"
-    }
   }
 }

--- a/test/views/html/cards/ChildBenefitSingleAccountViewSpec.scala
+++ b/test/views/html/cards/ChildBenefitSingleAccountViewSpec.scala
@@ -23,8 +23,8 @@ import views.html.cards.home.ChildBenefitSingleAccountView
 
 class ChildBenefitSingleAccountViewSpec extends ViewSpec {
 
-  val childBenefitSingleAccountView: ChildBenefitSingleAccountView = inject[ChildBenefitSingleAccountView]
-  implicit val configDecorator: ConfigDecorator                    = inject[ConfigDecorator]
+  lazy val childBenefitSingleAccountView: ChildBenefitSingleAccountView = inject[ChildBenefitSingleAccountView]
+  implicit lazy val configDecorator: ConfigDecorator                    = inject[ConfigDecorator]
 
   val nextDeadlineTaxYear = "2021"
 

--- a/test/views/html/cards/ItsaMergeViewSpec.scala
+++ b/test/views/html/cards/ItsaMergeViewSpec.scala
@@ -22,7 +22,7 @@ import views.html.cards.home.ItsaMergeView
 
 class ItsaMergeViewSpec extends ViewSpec {
 
-  val saAndItsaMergeView: ItsaMergeView         = inject[ItsaMergeView]
+  lazy val saAndItsaMergeView: ItsaMergeView    = inject[ItsaMergeView]
   implicit val configDecorator: ConfigDecorator = mock[ConfigDecorator] // inject[ConfigDecorator]
 
   val nextDeadlineTaxYear = "2021"

--- a/test/views/html/cards/LatestNewsAndUpdatesViewSpec.scala
+++ b/test/views/html/cards/LatestNewsAndUpdatesViewSpec.scala
@@ -24,7 +24,7 @@ import views.html.ViewSpec
 import views.html.cards.home.LatestNewsAndUpdatesView
 
 class LatestNewsAndUpdatesViewSpec extends ViewSpec {
-  val latestNewsAndUpdatesView: LatestNewsAndUpdatesView = app.injector.instanceOf[LatestNewsAndUpdatesView]
+  lazy val latestNewsAndUpdatesView: LatestNewsAndUpdatesView = app.injector.instanceOf[LatestNewsAndUpdatesView]
 
   override implicit lazy val app: Application = localGuiceApplicationBuilder().build()
 

--- a/test/views/html/cards/PayAsYouEarnViewSpec.scala
+++ b/test/views/html/cards/PayAsYouEarnViewSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.html.cards
+
+import config.ConfigDecorator
+import controllers.auth.requests.UserRequest
+import controllers.bindable.Origin
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import play.api
+import play.api.Application
+import play.api.i18n.Messages
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import repositories.JourneyCacheRepository
+import testUtils.Fixtures
+import testUtils.UserRequestFixture.buildUserRequest
+import uk.gov.hmrc.domain.Nino
+import views.html.ViewSpec
+import views.html.cards.home.{ChildBenefitSingleAccountView, PayAsYouEarnView}
+
+class PayAsYouEarnViewSpec extends ViewSpec {
+
+  lazy val payAsYouEarnView: PayAsYouEarnView       = inject[PayAsYouEarnView]
+  implicit val mockConfigDecorator: ConfigDecorator = mock[ConfigDecorator]
+
+  override implicit lazy val app: Application = localGuiceApplicationBuilder()
+    .overrides(
+      api.inject.bind[ConfigDecorator].toInstance(mockConfigDecorator),
+      api.inject.bind[JourneyCacheRepository].toInstance(mock[JourneyCacheRepository])
+    )
+    .build()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockConfigDecorator)
+    when(mockConfigDecorator.defaultOrigin).thenReturn(Origin("PERTAX"))
+    when(mockConfigDecorator.personalAccount).thenReturn("/personal-account")
+    when(mockConfigDecorator.getFeedbackSurveyUrl(any())).thenReturn("/feedback/url")
+    when(mockConfigDecorator.taiHost).thenReturn("")
+  }
+
+  val nextDeadlineTaxYear = "2021"
+
+  "paye point to check-income-tax when pega redirect is empty" in {
+    when(mockConfigDecorator.payeToPegaRedirectUrl).thenReturn("http://paye-to-pega-redirect-url")
+    when(mockConfigDecorator.payeToPegaRedirectList).thenReturn(Seq.empty)
+
+    val userRequest: UserRequest[AnyContentAsEmpty.type] =
+      buildUserRequest(request = FakeRequest())
+
+    val doc =
+      asDocument(
+        payAsYouEarnView()(implicitly, userRequest).toString
+      )
+
+    doc
+      .getElementById("paye-card")
+      .getElementsByClass("card-link")
+      .attr("href") mustBe "/check-income-tax/what-do-you-want-to-do"
+
+  }
+
+  "paye point to pega when nino is ending with 5" in {
+    when(mockConfigDecorator.payeToPegaRedirectUrl).thenReturn("http://paye-to-pega-redirect-url")
+    when(mockConfigDecorator.payeToPegaRedirectList).thenReturn(Seq(5))
+
+    val nino                                             = Fixtures.fakeNino.withoutSuffix.take(7)
+    val userRequest: UserRequest[AnyContentAsEmpty.type] =
+      buildUserRequest(request = FakeRequest(), authNino = Nino(nino + "5A"))
+
+    val doc =
+      asDocument(
+        payAsYouEarnView()(implicitly, userRequest).toString
+      )
+
+    doc
+      .getElementById("paye-card")
+      .getElementsByClass("card-link")
+      .attr("href") mustBe "http://paye-to-pega-redirect-url"
+
+  }
+
+  "paye point to check-income-tax when nino is not ending with 5" in {
+    when(mockConfigDecorator.payeToPegaRedirectUrl).thenReturn("http://paye-to-pega-redirect-url")
+    when(mockConfigDecorator.payeToPegaRedirectList).thenReturn(Seq(5))
+
+    val nino                                             = Fixtures.fakeNino.withoutSuffix.take(7)
+    val userRequest: UserRequest[AnyContentAsEmpty.type] =
+      buildUserRequest(request = FakeRequest(), authNino = Nino(nino + "3A"))
+
+    val doc =
+      asDocument(
+        payAsYouEarnView()(implicitly, userRequest).toString
+      )
+
+    doc
+      .getElementById("paye-card")
+      .getElementsByClass("card-link")
+      .attr("href") mustBe "/check-income-tax/what-do-you-want-to-do"
+
+  }
+}

--- a/test/views/html/cards/PayAsYouEarnViewSpec.scala
+++ b/test/views/html/cards/PayAsYouEarnViewSpec.scala
@@ -75,13 +75,13 @@ class PayAsYouEarnViewSpec extends ViewSpec {
 
   }
 
-  "paye point to pega when nino is ending with 5" in {
+  "paye point to pega when nino is ending with 50" in {
     when(mockConfigDecorator.payeToPegaRedirectUrl).thenReturn("http://paye-to-pega-redirect-url")
     when(mockConfigDecorator.payeToPegaRedirectList).thenReturn(Seq(5))
 
-    val nino                                             = Fixtures.fakeNino.withoutSuffix.take(7)
+    val nino                                             = Fixtures.fakeNino.withoutSuffix.take(6)
     val userRequest: UserRequest[AnyContentAsEmpty.type] =
-      buildUserRequest(request = FakeRequest(), authNino = Nino(nino + "5A"))
+      buildUserRequest(request = FakeRequest(), authNino = Nino(nino + "50A"))
 
     val doc =
       asDocument(
@@ -95,13 +95,13 @@ class PayAsYouEarnViewSpec extends ViewSpec {
 
   }
 
-  "paye point to check-income-tax when nino is not ending with 5" in {
+  "paye point to check-income-tax when nino is not ending with 50" in {
     when(mockConfigDecorator.payeToPegaRedirectUrl).thenReturn("http://paye-to-pega-redirect-url")
     when(mockConfigDecorator.payeToPegaRedirectList).thenReturn(Seq(5))
 
-    val nino                                             = Fixtures.fakeNino.withoutSuffix.take(7)
+    val nino                                             = Fixtures.fakeNino.withoutSuffix.take(6)
     val userRequest: UserRequest[AnyContentAsEmpty.type] =
-      buildUserRequest(request = FakeRequest(), authNino = Nino(nino + "3A"))
+      buildUserRequest(request = FakeRequest(), authNino = Nino(nino + "30A"))
 
     val doc =
       asDocument(


### PR DESCRIPTION
New config:
paye.to.pega.redirect.list = []
paye.to.pega.redirect.url = ""

paye.to.pega.redirect.list is a list of digits. Any nino finishing with this digit will be redirected to pega