### PR TITLE
PTAD-172: PTAP UCD: Tabular front end - Default text for no tasks and activity tabs

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -76,7 +76,8 @@ class HomeController @Inject() (
     }
 
   private def personalisationHomePageTab(tab: String)(implicit
-    request: UserRequest[AnyContent]
+    request: UserRequest[AnyContent],
+    messages: Messages
   ): Future[Result] =
     withValidTab(tab) { currentTab =>
       val nino: Nino = request.helpeeNinoOrElse
@@ -108,7 +109,7 @@ class HomeController @Inject() (
           val secondaryNav = buildSecondaryNav(currentTab, taskCount)
           val tabContent   = currentTab.cardContainerHeading.map { heading =>
             CardContainerModel(
-              emptyView = Html(""),
+              emptyView = currentTab.empty(),
               header = Some(heading),
               cards = tabContentCards.tabCards,
               headerId = Some("tab-content-header")

--- a/app/viewmodels/PtapHomeViewModel.scala
+++ b/app/viewmodels/PtapHomeViewModel.scala
@@ -17,6 +17,7 @@
 package viewmodels
 
 import models.{MyService, OtherService}
+import play.api.i18n.Messages
 import play.twirl.api.Html
 
 enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
@@ -26,9 +27,22 @@ enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
   case News extends TabEnum("hmrc-news")
   case Support extends TabEnum("support")
 
-  def href(): String = this match {
+  def href(): String                             = this match {
     case Task => "/personal-account"
     case tab  => s"/personal-account/${tab.name}"
+  }
+  def empty()(implicit messages: Messages): Html = this match {
+    case Task =>
+      Html(s"""
+                <div class="govuk-inset-text">
+                  <p class="govuk-body">${messages("ptap.tasks.uya.default.l1")}</p>
+                  <p class="govuk-body">${messages("ptap.tasks.uya.default.l2.1")} <a href="${Tax
+          .href()}" class="govuk-link">${messages("ptap.tasks.uya.default.l2.2")}</a> ${messages(
+          "ptap.tasks.uya.default.l2.3"
+        )}</p>
+                </div>
+              """)
+    case _    => Html("")
   }
 
 final case class PtapNewsAndUpdates(content: Html) extends AnyVal

--- a/app/viewmodels/PtapHomeViewModel.scala
+++ b/app/viewmodels/PtapHomeViewModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package viewmodels
 
 import models.{MyService, OtherService}
+import views.html.components.TabDefaultInsetText
 import play.api.i18n.Messages
 import play.twirl.api.Html
 
@@ -31,33 +32,8 @@ enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
     case Task => "/personal-account"
     case tab  => s"/personal-account/${tab.name}"
   }
-  def empty()(implicit messages: Messages): Html = this match {
-    case Task     =>
-      Html(s"""
-                <div class="govuk-inset-text">
-                  <p class="govuk-body">${messages("ptap.tasks.container.default_text.p.line1")}</p>
-                  <p class="govuk-body govuk-!-margin-bottom-0">${messages(
-          "ptap.tasks.container.default_text.p.line2.1"
-        )} <a href="${Tax
-          .href()}" class="govuk-link">${messages("ptap.tasks.container.default_text.p.line2.2")}</a> ${messages(
-          "ptap.tasks.container.default_text.p.line2.3"
-        )}</p>
-                </div>
-              """)
-    case Activity =>
-      Html(s"""
-          <div class="govuk-inset-text">
-                  <p class="govuk-body">${messages("ptap.activity.container.default_text.p.line1")}</p>
-                  <p class="govuk-body govuk-!-margin-bottom-0">${messages(
-          "ptap.tasks.container.default_text.p.line2.1"
-        )} <a href="${Task
-          .href()}" class="govuk-link">${messages("ptap.activity.container.default_text.p.line2.2")}</a> ${messages(
-          "ptap.activity.container.default_text.p.line2.3"
-        )}</p>
-                </div>
-    """)
-    case _        => Html("")
-  }
+  def empty()(implicit messages: Messages): Html =
+    TabDefaultInsetText(this)
 
 final case class PtapNewsAndUpdates(content: Html) extends AnyVal
 final case class PtapAlertBanner(content: Html) extends AnyVal

--- a/app/viewmodels/PtapHomeViewModel.scala
+++ b/app/viewmodels/PtapHomeViewModel.scala
@@ -32,7 +32,7 @@ enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
     case tab  => s"/personal-account/${tab.name}"
   }
   def empty()(implicit messages: Messages): Html = this match {
-    case Task =>
+    case Task     =>
       Html(s"""
                 <div class="govuk-inset-text">
                   <p class="govuk-body">${messages("ptap.tasks.uya.default.l1")}</p>
@@ -42,7 +42,17 @@ enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
         )}</p>
                 </div>
               """)
-    case _    => Html("")
+    case Activity =>
+      Html(s"""
+          <div class="govuk-inset-text">
+                  <p class="govuk-body">${messages("ptap.activity.uya.default.l1")}</p>
+                  <p class="govuk-body">${messages("ptap.tasks.uya.default.l2.1")} <a href="${Activity
+          .href()}" class="govuk-link">${messages("ptap.tasks.uya.default.l2.2")}</a> ${messages(
+          "ptap.tasks.uya.default.l2.3"
+        )}</p>
+                </div>
+    """)
+    case _        => Html("")
   }
 
 final case class PtapNewsAndUpdates(content: Html) extends AnyVal

--- a/app/viewmodels/PtapHomeViewModel.scala
+++ b/app/viewmodels/PtapHomeViewModel.scala
@@ -35,24 +35,24 @@ enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
     case Task     =>
       Html(s"""
                 <div class="govuk-inset-text">
-                  <p class="govuk-body">${messages("ptap.tasks.uya.default.l1")}</p>
+                  <p class="govuk-body">${messages("ptap.tasks.container.default_text.p.line1")}</p>
                   <p class="govuk-body govuk-!-margin-bottom-0">${messages(
-          "ptap.tasks.uya.default.l2.1"
+          "ptap.tasks.container.default_text.p.line2.1"
         )} <a href="${Tax
-          .href()}" class="govuk-link">${messages("ptap.tasks.uya.default.l2.2")}</a> ${messages(
-          "ptap.tasks.uya.default.l2.3"
+          .href()}" class="govuk-link">${messages("ptap.tasks.container.default_text.p.line2.2")}</a> ${messages(
+          "ptap.tasks.container.default_text.p.line2.3"
         )}</p>
                 </div>
               """)
     case Activity =>
       Html(s"""
           <div class="govuk-inset-text">
-                  <p class="govuk-body">${messages("ptap.activity.uya.default.l1")}</p>
+                  <p class="govuk-body">${messages("ptap.activity.container.default_text.p.line1")}</p>
                   <p class="govuk-body govuk-!-margin-bottom-0">${messages(
-          "ptap.tasks.uya.default.l2.1"
+          "ptap.tasks.container.default_text.p.line2.1"
         )} <a href="${Task
-          .href()}" class="govuk-link">${messages("ptap.activity.uya.default.l2.2")}</a> ${messages(
-          "ptap.tasks.uya.default.l2.3"
+          .href()}" class="govuk-link">${messages("ptap.activity.container.default_text.p.line2.2")}</a> ${messages(
+          "ptap.activity.container.default_text.p.line2.3"
         )}</p>
                 </div>
     """)

--- a/app/viewmodels/PtapHomeViewModel.scala
+++ b/app/viewmodels/PtapHomeViewModel.scala
@@ -36,7 +36,9 @@ enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
       Html(s"""
                 <div class="govuk-inset-text">
                   <p class="govuk-body">${messages("ptap.tasks.uya.default.l1")}</p>
-                  <p class="govuk-body">${messages("ptap.tasks.uya.default.l2.1")} <a href="${Tax
+                  <p class="govuk-body govuk-!-margin-bottom-0">${messages(
+          "ptap.tasks.uya.default.l2.1"
+        )} <a href="${Tax
           .href()}" class="govuk-link">${messages("ptap.tasks.uya.default.l2.2")}</a> ${messages(
           "ptap.tasks.uya.default.l2.3"
         )}</p>
@@ -46,8 +48,10 @@ enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
       Html(s"""
           <div class="govuk-inset-text">
                   <p class="govuk-body">${messages("ptap.activity.uya.default.l1")}</p>
-                  <p class="govuk-body">${messages("ptap.tasks.uya.default.l2.1")} <a href="${Activity
-          .href()}" class="govuk-link">${messages("ptap.tasks.uya.default.l2.2")}</a> ${messages(
+                  <p class="govuk-body govuk-!-margin-bottom-0">${messages(
+          "ptap.tasks.uya.default.l2.1"
+        )} <a href="${Task
+          .href()}" class="govuk-link">${messages("ptap.activity.uya.default.l2.2")}</a> ${messages(
           "ptap.tasks.uya.default.l2.3"
         )}</p>
                 </div>

--- a/app/views/components/TabDefaultInsetText.scala.html
+++ b/app/views/components/TabDefaultInsetText.scala.html
@@ -37,6 +37,6 @@
     @if(tab == Task|| tab == Activity){
         <div class="govuk-inset-text">
             <p class="govuk-body">@messages(s"ptap.${tab.name}.container.default_text.p.line1")</p>
-            <p class="govuk-body govuk-!-margin-bottom-0">@messages("ptap.your-tasks.container.default_text.p.line2.1") <a href="@Tax.href()" class="govuk-link">@messages(s"ptap.${tab.name}.container.default_text.p.line2.2")</a> @messages(s"ptap.${tab.name}.container.default_text.p.line2.3")</p>
+            <p class="govuk-body govuk-!-margin-bottom-0">@messages("ptap.your-tasks.container.default_text.p.line2.1") <a href="@if(tab == Task){@Tax.href()}else{@Task.href()}" class="govuk-link">@messages(s"ptap.${tab.name}.container.default_text.p.line2.2")</a> @messages(s"ptap.${tab.name}.container.default_text.p.line2.3")</p>
         </div>
     }

--- a/app/views/components/TabDefaultInsetText.scala.html
+++ b/app/views/components/TabDefaultInsetText.scala.html
@@ -1,0 +1,42 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **@    
+
+@import viewmodels.TabEnum
+@import viewmodels.TabEnum.*
+
+@(tab: TabEnum)(implicit messages: Messages)
+    @if(tab == Task|| tab == Activity){
+        <div class="govuk-inset-text">
+            <p class="govuk-body">@messages(s"ptap.${tab.name}.container.default_text.p.line1")</p>
+            <p class="govuk-body govuk-!-margin-bottom-0">@messages("ptap.your-tasks.container.default_text.p.line2.1") <a href="@Tax.href()" class="govuk-link">@messages(s"ptap.${tab.name}.container.default_text.p.line2.2")</a> @messages(s"ptap.${tab.name}.container.default_text.p.line2.3")</p>
+        </div>
+    }

--- a/conf/messages
+++ b/conf/messages
@@ -859,6 +859,14 @@ label.mtdit.claim.question=Do you want to add Making Tax Digital for Income Tax 
 label.mtdit.claim.error=Select yes to add Making Tax Digital for Income Tax to your personal tax account
 head.label.mtdit.claim.error=Select yes to add Making Tax Digital for Income Tax to your personal tax account
 
+#************************************************************
+# Default case (no tasks)
+#************************************************************
+ptap.tasks.uya.default.l1=This page shows your PAYE tasks.
+ptap.tasks.uya.default.l2.1=Check
+ptap.tasks.uya.default.l2.2= Taxes and benefits
+ptap.tasks.uya.default.l2.3= for anything else you need to do.
+
 ptap.support.uya.title=Understanding your HMRC Online account
 ptap.support.uya.p1=Your HMRC Online account lets you manage your taxes and benefits in one place.
 ptap.support.uya.p1.list=You can use it to access:

--- a/conf/messages
+++ b/conf/messages
@@ -862,17 +862,17 @@ head.label.mtdit.claim.error=Select yes to add Making Tax Digital for Income Tax
 #************************************************************
 # Default case (no tasks)
 #************************************************************
-ptap.tasks.container.default_text.p.line1=This page shows refunds and tax you owe.
-ptap.tasks.container.default_text.p.line2.1=Check
-ptap.tasks.container.default_text.p.line2.2=Taxes and benefits
-ptap.tasks.container.default_text.p.line2.3=for anything else you need to do.
+ptap.your-tasks.container.default_text.p.line1=This page shows refunds and tax you owe.
+ptap.your-tasks.container.default_text.p.line2.1=Check
+ptap.your-tasks.container.default_text.p.line2.2=Taxes and benefits
+ptap.your-tasks.container.default_text.p.line2.3=for anything else you need to do.
 
 #************************************************************
 # Default case (no activity)
 #************************************************************
-ptap.activity.container.default_text.p.line1=This page shows your recent activity.
-ptap.activity.container.default_text.p.line2.2=Your tasks
-ptap.activity.container.default_text.p.line2.3=for anything you need to do.
+ptap.recent-activity.container.default_text.p.line1=This page shows your recent activity.
+ptap.recent-activity.container.default_text.p.line2.2=Your tasks
+ptap.recent-activity.container.default_text.p.line2.3=for anything you need to do.
 
 ptap.support.uya.title=Understanding your HMRC Online account
 ptap.support.uya.p1=Your HMRC Online account lets you manage your taxes and benefits in one place.

--- a/conf/messages
+++ b/conf/messages
@@ -867,6 +867,12 @@ ptap.tasks.uya.default.l2.1=Check
 ptap.tasks.uya.default.l2.2= Taxes and benefits
 ptap.tasks.uya.default.l2.3= for anything else you need to do.
 
+#************************************************************
+# Default case (no tasks)
+#************************************************************
+ptap.activity.uya.default.l1=This page shows your recent activity.
+ptap.activity.uya.default.l2.2=Recent Activity
+
 ptap.support.uya.title=Understanding your HMRC Online account
 ptap.support.uya.p1=Your HMRC Online account lets you manage your taxes and benefits in one place.
 ptap.support.uya.p1.list=You can use it to access:

--- a/conf/messages
+++ b/conf/messages
@@ -862,16 +862,16 @@ head.label.mtdit.claim.error=Select yes to add Making Tax Digital for Income Tax
 #************************************************************
 # Default case (no tasks)
 #************************************************************
-ptap.tasks.uya.default.l1=This page shows your PAYE tasks.
+ptap.tasks.uya.default.l1=This page shows refunds and tax you owe.
 ptap.tasks.uya.default.l2.1=Check
 ptap.tasks.uya.default.l2.2= Taxes and benefits
 ptap.tasks.uya.default.l2.3= for anything else you need to do.
 
 #************************************************************
-# Default case (no tasks)
+# Default case (no activity)
 #************************************************************
 ptap.activity.uya.default.l1=This page shows your recent activity.
-ptap.activity.uya.default.l2.2=Recent Activity
+ptap.activity.uya.default.l2.2=Your tasks
 
 ptap.support.uya.title=Understanding your HMRC Online account
 ptap.support.uya.p1=Your HMRC Online account lets you manage your taxes and benefits in one place.

--- a/conf/messages
+++ b/conf/messages
@@ -862,16 +862,17 @@ head.label.mtdit.claim.error=Select yes to add Making Tax Digital for Income Tax
 #************************************************************
 # Default case (no tasks)
 #************************************************************
-ptap.tasks.uya.default.l1=This page shows refunds and tax you owe.
-ptap.tasks.uya.default.l2.1=Check
-ptap.tasks.uya.default.l2.2= Taxes and benefits
-ptap.tasks.uya.default.l2.3= for anything else you need to do.
+ptap.tasks.container.default_text.p.line1=This page shows refunds and tax you owe.
+ptap.tasks.container.default_text.p.line2.1=Check
+ptap.tasks.container.default_text.p.line2.2=Taxes and benefits
+ptap.tasks.container.default_text.p.line2.3=for anything else you need to do.
 
 #************************************************************
 # Default case (no activity)
 #************************************************************
-ptap.activity.uya.default.l1=This page shows your recent activity.
-ptap.activity.uya.default.l2.2=Your tasks
+ptap.activity.container.default_text.p.line1=This page shows your recent activity.
+ptap.activity.container.default_text.p.line2.2=Your tasks
+ptap.activity.container.default_text.p.line2.3=for anything you need to do.
 
 ptap.support.uya.title=Understanding your HMRC Online account
 ptap.support.uya.p1=Your HMRC Online account lets you manage your taxes and benefits in one place.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -871,6 +871,14 @@ label.mtdit.claim.question=A ydych am ychwanegu’r cynllun Troi Treth yn Ddigid
 label.mtdit.claim.error=Dewiswch ‘Iawn’ i ychwanegu’r cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm i’ch cyfrif treth personol
 head.label.mtdit.claim.error=Dewiswch ‘Iawn’ i ychwanegu’r cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm i’ch cyfrif treth personol
 
+#************************************************************
+# Default case (no tasks)
+#************************************************************
+ptap.tasks.uya.default.l1= TBD
+ptap.tasks.uya.default.l2.1=TBD
+ptap.tasks.uya.default.l2.2= TBD
+ptap.tasks.uya.default.l2.3= TBD
+
 ptap.support.uya.title=TBC
 ptap.support.uya.p1=TBC
 ptap.support.uya.p1.list=TBC

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -874,10 +874,16 @@ head.label.mtdit.claim.error=Dewiswch ‘Iawn’ i ychwanegu’r cynllun Troi Tr
 #************************************************************
 # Default case (no tasks)
 #************************************************************
-ptap.tasks.uya.default.l1= TBD
-ptap.tasks.uya.default.l2.1=TBD
-ptap.tasks.uya.default.l2.2= TBD
-ptap.tasks.uya.default.l2.3= TBD
+ptap.tasks.uya.default.l1=TBC
+ptap.tasks.uya.default.l2.1=TBC
+ptap.tasks.uya.default.l2.2=TBC
+ptap.tasks.uya.default.l2.3=TBC
+
+#************************************************************
+# Default case (no tasks)
+#************************************************************
+ptap.activity.uya.default.l1=TBC
+ptap.activity.uya.default.l2.2=TBC
 
 ptap.support.uya.title=TBC
 ptap.support.uya.p1=TBC

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -874,16 +874,17 @@ head.label.mtdit.claim.error=Dewiswch ‘Iawn’ i ychwanegu’r cynllun Troi Tr
 #************************************************************
 # Default case (no tasks)
 #************************************************************
-ptap.tasks.uya.default.l1=TBC
-ptap.tasks.uya.default.l2.1=TBC
-ptap.tasks.uya.default.l2.2=TBC
-ptap.tasks.uya.default.l2.3=TBC
+ptap.tasks.container.default_text.p.line1=TBC
+ptap.tasks.container.default_text.p.line2.1=TBC
+ptap.tasks.container.default_text.p.line2.2=Trethi a budd-daliadau
+ptap.tasks.container.default_text.p.line2.3=TBC
 
 #************************************************************
 # Default case (no activity)
 #************************************************************
-ptap.activity.uya.default.l1=TBC
-ptap.activity.uya.default.l2.2=TBC
+ptap.activity.container.default_text.p.line1=TBC
+ptap.activity.container.default_text.p.line2.2=TBC
+ptap.activity.container.default_text.p.line2.3= TBC
 
 ptap.support.uya.title=TBC
 ptap.support.uya.p1=TBC

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -880,7 +880,7 @@ ptap.tasks.uya.default.l2.2=TBC
 ptap.tasks.uya.default.l2.3=TBC
 
 #************************************************************
-# Default case (no tasks)
+# Default case (no activity)
 #************************************************************
 ptap.activity.uya.default.l1=TBC
 ptap.activity.uya.default.l2.2=TBC

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -874,17 +874,17 @@ head.label.mtdit.claim.error=Dewiswch ‘Iawn’ i ychwanegu’r cynllun Troi Tr
 #************************************************************
 # Default case (no tasks)
 #************************************************************
-ptap.tasks.container.default_text.p.line1=TBC
-ptap.tasks.container.default_text.p.line2.1=TBC
-ptap.tasks.container.default_text.p.line2.2=Trethi a budd-daliadau
-ptap.tasks.container.default_text.p.line2.3=TBC
+ptap.your-tasks.container.default_text.p.line1=TBC
+ptap.your-tasks.container.default_text.p.line2.1=TBC
+ptap.your-tasks.container.default_text.p.line2.2=Trethi a budd-daliadau
+ptap.your-tasks.container.default_text.p.line2.3=TBC
 
 #************************************************************
 # Default case (no activity)
 #************************************************************
-ptap.activity.container.default_text.p.line1=TBC
-ptap.activity.container.default_text.p.line2.2=TBC
-ptap.activity.container.default_text.p.line2.3= TBC
+ptap.recent-activity.container.default_text.p.line1=TBC
+ptap.recent-activity.container.default_text.p.line2.2=TBC
+ptap.recent-activity.container.default_text.p.line2.3= TBC
 
 ptap.support.uya.title=TBC
 ptap.support.uya.p1=TBC

--- a/test/views/html/PtapHomeViewSpec.scala
+++ b/test/views/html/PtapHomeViewSpec.scala
@@ -80,7 +80,7 @@ class PtapHomeViewSpec extends ViewSpec {
     headerId: String = "tab-content-header"
   ): CardContainerModel =
     CardContainerModel(
-      emptyView = Html(""),
+      emptyView = Task.empty(),
       header = Some("Your tasks"),
       cards = cards,
       headerId = Some(headerId)
@@ -284,6 +284,26 @@ class PtapHomeViewSpec extends ViewSpec {
       implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
       val doc                                                       = asDocument(home(homeViewModel.copy(breathingSpaceIndicator = false)).toString)
       doc.text() must not include "BREATHING SPACE"
+    }
+    "show the default placeholder content when the Your Tasks tab is selected and there are no cards to load." in {
+      implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
+      val viewModel                                                 = homeViewModel.copy(tabContent = List(taskTabContent()))
+      val doc                                                       = asDocument(home(viewModel).toString)
+
+      val placeholder_text = doc
+        .select("div.govuk-grid-column-two-thirds")
+        .select("div.govuk-inset-text")
+      placeholder_text.size mustBe 1
+      placeholder_text.select("p.govuk-body").size mustBe 2
+
+      val first_line  = placeholder_text.select("p.govuk-body").asList().get(0)
+      val second_line = placeholder_text.select("p.govuk-body").asList().get(1)
+      first_line.text()                          must include(messages("ptap.tasks.uya.default.l1"))
+      second_line
+        .text() mustBe s"${messages("ptap.tasks.uya.default.l2.1")} ${messages("ptap.tasks.uya.default.l2.2")} ${messages("ptap.tasks.uya.default.l2.3")}"
+      second_line.select(s"a.govuk-link").text() must include(
+        messages("ptap.tasks.uya.default.l2.2")
+      )
     }
   }
 }

--- a/test/views/html/PtapHomeViewSpec.scala
+++ b/test/views/html/PtapHomeViewSpec.scala
@@ -87,7 +87,7 @@ class PtapHomeViewSpec extends ViewSpec {
     )
 
   private def activityTabContent(
-    cards: Seq[models.HmrcCardModel],
+    cards: Seq[models.HmrcCardModel] = Seq.empty,
     headerId: String = "tab-content-header"
   ): CardContainerModel =
     CardContainerModel(
@@ -297,6 +297,28 @@ class PtapHomeViewSpec extends ViewSpec {
         .text() mustBe s"${messages("ptap.tasks.uya.default.l2.1")} ${messages("ptap.tasks.uya.default.l2.2")} ${messages("ptap.tasks.uya.default.l2.3")}"
       second_line.select(s"a.govuk-link").text() must include(
         messages("ptap.tasks.uya.default.l2.2")
+      )
+    }
+    "show the default placeholder content when the Recent activity tab is selected and there are no cards to load." in {
+      implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
+      val activityNav                                               = defaultSecondaryNav.copy(
+        items = defaultSecondaryNav.items.map(i => i.copy(current = i.href == Activity.href()))
+      )
+      val viewModel                                                 = homeViewModel.copy(secondaryNav = activityNav, tabContent = List(activityTabContent()))
+      val doc                                                       = asDocument(home(viewModel).toString)
+      val placeholder_text                                          = doc
+        .select("div.govuk-grid-column-two-thirds")
+        .select("div.govuk-inset-text")
+      placeholder_text.size mustBe 1
+      placeholder_text.select("p.govuk-body").size mustBe 2
+      println(placeholder_text)
+      val first_line                                                = placeholder_text.select("p.govuk-body").asList().get(0)
+      val second_line                                               = placeholder_text.select("p.govuk-body").asList().get(1)
+      first_line.text()                          must include(messages("ptap.activity.uya.default.l1"))
+      second_line
+        .text() mustBe s"${messages("ptap.tasks.uya.default.l2.1")} ${messages("ptap.activity.uya.default.l2.2")} ${messages("ptap.tasks.uya.default.l2.3")}"
+      second_line.select(s"a.govuk-link").text() must include(
+        messages("ptap.activity.uya.default.l2.2")
       )
     }
   }

--- a/test/views/html/PtapHomeViewSpec.scala
+++ b/test/views/html/PtapHomeViewSpec.scala
@@ -91,7 +91,7 @@ class PtapHomeViewSpec extends ViewSpec {
     headerId: String = "tab-content-header"
   ): CardContainerModel =
     CardContainerModel(
-      emptyView = Html(""),
+      emptyView = Activity.empty(),
       header = Some("Recent activity"),
       cards = cards,
       headerId = Some(headerId)
@@ -311,7 +311,6 @@ class PtapHomeViewSpec extends ViewSpec {
         .select("div.govuk-inset-text")
       placeholder_text.size mustBe 1
       placeholder_text.select("p.govuk-body").size mustBe 2
-      println(placeholder_text)
       val first_line                                                = placeholder_text.select("p.govuk-body").asList().get(0)
       val second_line                                               = placeholder_text.select("p.govuk-body").asList().get(1)
       first_line.text()                          must include(messages("ptap.activity.uya.default.l1"))

--- a/test/views/html/PtapHomeViewSpec.scala
+++ b/test/views/html/PtapHomeViewSpec.scala
@@ -292,12 +292,10 @@ class PtapHomeViewSpec extends ViewSpec {
 
       val first_line  = placeholder_text.select("p.govuk-body").asList().get(0)
       val second_line = placeholder_text.select("p.govuk-body").asList().get(1)
-      first_line.text()                          must include(messages("ptap.tasks.uya.default.l1"))
+      first_line.text() mustBe "This page shows refunds and tax you owe."
       second_line
-        .text() mustBe s"${messages("ptap.tasks.uya.default.l2.1")} ${messages("ptap.tasks.uya.default.l2.2")} ${messages("ptap.tasks.uya.default.l2.3")}"
-      second_line.select(s"a.govuk-link").text() must include(
-        messages("ptap.tasks.uya.default.l2.2")
-      )
+        .text() mustBe "Check Taxes and benefits for anything else you need to do."
+      second_line.select(s"a.govuk-link").text() mustBe "Taxes and benefits"
     }
     "show the default placeholder content when the Recent activity tab is selected and there are no cards to load." in {
       implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
@@ -313,12 +311,10 @@ class PtapHomeViewSpec extends ViewSpec {
       placeholder_text.select("p.govuk-body").size mustBe 2
       val first_line                                                = placeholder_text.select("p.govuk-body").asList().get(0)
       val second_line                                               = placeholder_text.select("p.govuk-body").asList().get(1)
-      first_line.text()                          must include(messages("ptap.activity.uya.default.l1"))
+      first_line.text() mustBe "This page shows your recent activity."
       second_line
-        .text() mustBe s"${messages("ptap.tasks.uya.default.l2.1")} ${messages("ptap.activity.uya.default.l2.2")} ${messages("ptap.tasks.uya.default.l2.3")}"
-      second_line.select(s"a.govuk-link").text() must include(
-        messages("ptap.activity.uya.default.l2.2")
-      )
+        .text() mustBe "Check Your tasks for anything you need to do."
+      second_line.select(s"a.govuk-link").text() mustBe "Your tasks"
     }
   }
 }

--- a/test/views/html/PtapHomeViewSpec.scala
+++ b/test/views/html/PtapHomeViewSpec.scala
@@ -223,12 +223,6 @@ class PtapHomeViewSpec extends ViewSpec {
       doc.select(".hmrc-card__heading").text() must include("HMRC owes you a refund for 2022-23")
     }
 
-    "render an empty card container when no tab cards are provided" in {
-      implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
-      val doc                                                       = asDocument(home(homeViewModel).toString)
-      doc.select(".hmrc-card").size() mustBe 0
-    }
-
     "render the task count badge on the tasks tab nav item" in {
       implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
       val doc                                                       = asDocument(home(homeViewModel).toString)
@@ -285,7 +279,7 @@ class PtapHomeViewSpec extends ViewSpec {
       val doc                                                       = asDocument(home(homeViewModel.copy(breathingSpaceIndicator = false)).toString)
       doc.text() must not include "BREATHING SPACE"
     }
-    "show the default placeholder content when the Your Tasks tab is selected and there are no cards to load." in {
+    "show the default placeholder content when the Your tasks tab is selected and there are no cards to load." in {
       implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
       val viewModel                                                 = homeViewModel.copy(tabContent = List(taskTabContent()))
       val doc                                                       = asDocument(home(viewModel).toString)


### PR DESCRIPTION
Ticket: [PTAD-172](https://jira.tools.tax.service.gov.uk/browse/PTAD-172)

- Added new lines to the messages file for placeholder messages.
  - Added place holders for Welsh in interim before Welsh content is updated.
- empty() method added to TabEnum, which returns the defined placeholder text if present for that tab.
- Added unit test to PtapHomeViewSpec check rendering of the default text of 'Your tasks' tab and 'Recent activity' tab
