### PR TITLE
PTAD-193 Add Taxes and benefits tab heading

### DIFF
--- a/app/viewmodels/CardContainerModel.scala
+++ b/app/viewmodels/CardContainerModel.scala
@@ -24,11 +24,13 @@ final case class CardContainerModel(
   header: Option[CardContainerModel.Header] = None,
   cards: Seq[HmrcCardModel] = Seq.empty,
   headingLevel: String = "h2",
+  cardHeadingLevel: String = "h3",
   listAriaLabel: Option[String] = None,
   headerId: Option[String] = None,
   headerClasses: Option[String] = None
 ) {
   val normalizedHeadingLevel: String          = headingLevel.trim.toLowerCase
+  val normalizedCardHeadingLevel: String      = cardHeadingLevel.trim.toLowerCase
   val normalizedHeader: Option[Html]          = header.flatMap(CardContainerModel.normalizeHeader)
   val normalizedListAriaLabel: Option[String] = listAriaLabel.map(_.trim).filter(_.nonEmpty)
   val normalizedHeaderId: Option[String]      = headerId.map(_.trim).filter(_.nonEmpty)
@@ -38,6 +40,11 @@ final case class CardContainerModel(
   require(
     CardContainerModel.ValidHeadingLevels.contains(normalizedHeadingLevel),
     s"Invalid heading level: $headingLevel. Must be h1-h6."
+  )
+
+  require(
+    CardContainerModel.ValidHeadingLevels.contains(normalizedCardHeadingLevel),
+    s"Invalid card heading level: $cardHeadingLevel. Must be h1-h6."
   )
 
   require(

--- a/app/viewmodels/CardContainerModel.scala
+++ b/app/viewmodels/CardContainerModel.scala
@@ -25,12 +25,15 @@ final case class CardContainerModel(
   cards: Seq[HmrcCardModel] = Seq.empty,
   headingLevel: String = "h2",
   listAriaLabel: Option[String] = None,
-  headerId: Option[String] = None
+  headerId: Option[String] = None,
+  headerClasses: Option[String] = None
 ) {
   val normalizedHeadingLevel: String          = headingLevel.trim.toLowerCase
   val normalizedHeader: Option[Html]          = header.flatMap(CardContainerModel.normalizeHeader)
   val normalizedListAriaLabel: Option[String] = listAriaLabel.map(_.trim).filter(_.nonEmpty)
   val normalizedHeaderId: Option[String]      = headerId.map(_.trim).filter(_.nonEmpty)
+  val normalizedHeaderClasses: String         =
+    headerClasses.map(_.trim).filter(_.nonEmpty).getOrElse("govuk-heading-m")
 
   require(
     CardContainerModel.ValidHeadingLevels.contains(normalizedHeadingLevel),

--- a/app/views/components/HmrcCard.scala.html
+++ b/app/views/components/HmrcCard.scala.html
@@ -21,7 +21,12 @@
 @import play.twirl.api.HtmlFormat
 @import play.api.i18n.Messages
 
-@(hmrcCard: HmrcCardModel)(implicit messages: Messages)
+@(hmrcCard: HmrcCardModel, headingLevel: String = "h3")(implicit messages: Messages)
+@headingTag = @{
+    val normalizedHeadingLevel = headingLevel.trim.toLowerCase
+    require(Set("h1", "h2", "h3", "h4", "h5", "h6").contains(normalizedHeadingLevel), s"Invalid heading level: $headingLevel. Must be h1-h6.")
+    normalizedHeadingLevel
+}
 @headerWithLink(url: String)={
     @if(hmrcCard.heading.opensNewTab){
         <a href="@url" target="_blank" rel="noopener noreferrer">
@@ -58,9 +63,9 @@
     </p>
 }
 <div class="hmrc-card">
-    <h3 class="hmrc-card__heading">
+    <@headingTag class="hmrc-card__heading">
         @{hmrcCard.heading.url.map{headerWithLink}.getOrElse{headerWithoutLink()}}
-    </h3>
+    </@headingTag>
     @hmrcCard.body.map{(b: CardBody) => @{cardBody(b)}}.getOrElse{@HtmlFormat.empty}
     @hmrcCard.hint.map{(h: CardHint) => @{cardHint(h)}}.getOrElse{@HtmlFormat.empty}
 </div>

--- a/app/views/home.options/TaxesAndBenefitsView.scala.html
+++ b/app/views/home.options/TaxesAndBenefitsView.scala.html
@@ -14,12 +14,13 @@
  * limitations under the License.
  *@
 
+@import components.H2
 @import models.{CardType, CardHeading, HmrcCardModel, MyService, OtherService}
 @import viewmodels.CardContainerModel
 @import tags.CardContainer
 @import play.twirl.api.HtmlFormat
 
-@this(cardContainer: CardContainer)
+@this(cardContainer: CardContainer, h2: H2)
 
 @(myServices: Seq[MyService], otherServices: Seq[OtherService])(implicit messages: play.api.i18n.Messages)
 
@@ -47,10 +48,14 @@
     }
 }
 
+@h2("label.taxes_and_benefits_heading", elmId = Some("taxes-and-benefits-tab-heading"))
+
 @if(myServiceCards.nonEmpty) {
     @cardContainer(CardContainerModel(
         header = Some(messages("label.taxes_and_benefits_subheading")),
         headerId = Some("my-services-heading"),
+        headingLevel = "h3",
+        headerClasses = Some("govuk-heading-s"),
         emptyView = HtmlFormat.empty,
         cards = myServiceCards
     ))
@@ -60,6 +65,8 @@
     @cardContainer(CardContainerModel(
         header = Some(messages("label.other_taxes_and_benefits_heading")),
         headerId = Some("other-services-heading"),
+        headingLevel = "h3",
+        headerClasses = Some("govuk-heading-s govuk-!-margin-top-5"),
         emptyView = HtmlFormat.empty,
         cards = otherServiceCards
     ))

--- a/app/views/home.options/TaxesAndBenefitsView.scala.html
+++ b/app/views/home.options/TaxesAndBenefitsView.scala.html
@@ -55,6 +55,7 @@
         header = Some(messages("label.taxes_and_benefits_subheading")),
         headerId = Some("my-services-heading"),
         headingLevel = "h3",
+        cardHeadingLevel = "h4",
         headerClasses = Some("govuk-heading-s"),
         emptyView = HtmlFormat.empty,
         cards = myServiceCards
@@ -66,6 +67,7 @@
         header = Some(messages("label.other_taxes_and_benefits_heading")),
         headerId = Some("other-services-heading"),
         headingLevel = "h3",
+        cardHeadingLevel = "h4",
         headerClasses = Some("govuk-heading-s govuk-!-margin-top-5"),
         emptyView = HtmlFormat.empty,
         cards = otherServiceCards

--- a/app/views/tags/CardContainer.scala.html
+++ b/app/views/tags/CardContainer.scala.html
@@ -34,14 +34,14 @@
 @if(model.cards.isEmpty) {
   @model.emptyView
 } else if(model.cards.length == 1) {
-  @HmrcCard(model.cards.head)
+  @HmrcCard(model.cards.head, model.normalizedCardHeadingLevel)
 } else {
   <ul class="hmrc-card__container"
       @listLabel.map { label => aria-label="@label" }
       @if(listLabel.isEmpty) { aria-labelledby="@headerIdValue" }>
     @for(card <- model.cards) {
       <li class="hmrc-card__list-item">
-        @HmrcCard(card)
+        @HmrcCard(card, model.normalizedCardHeadingLevel)
       </li>
     }
   </ul>

--- a/app/views/tags/CardContainer.scala.html
+++ b/app/views/tags/CardContainer.scala.html
@@ -26,7 +26,7 @@
 @listLabel = @{model.normalizedListAriaLabel}
 
 @if(model.normalizedHeader.isDefined) {
-  <@headingTag id="@headerIdValue" class="govuk-heading-m">
+  <@headingTag id="@headerIdValue" class="@model.normalizedHeaderClasses">
     @model.normalizedHeader.get
   </@headingTag>
 }

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -619,6 +619,7 @@ class HomeControllerSpec extends BaseSpec with WireMockHelper with CitizenDetail
 
       val content = Jsoup.parse(contentAsString(result))
       content.select("nav.x-govuk-secondary-navigation").size mustBe 1
+      content.select("h2#taxes-and-benefits-tab-heading").text mustBe "Taxes and benefits"
       content.getElementById("my-services-heading") must not be null
       content.select("div.hmrc-card").size mustBe 2
       content.getElementsContainingText("Pay As You Earn (PAYE)").attr("href") mustBe "/paye"

--- a/test/views/html/components/HmrcCardSpec.scala
+++ b/test/views/html/components/HmrcCardSpec.scala
@@ -104,6 +104,21 @@ class HmrcCardSpec extends ViewSpec with Matchers {
       doc.select("span.govuk-\\!-font-weight-regular").size mustBe 1
       doc.select("span.govuk-\\!-font-weight-regular").text mustBe "(opens in new tab)"
     }
+    "render with configured heading level" in {
+      val model = HmrcCardModel(CardType.BasicCard, CardHeading("Test Heading", Some("/test"), false), None, None)
+
+      val doc = asDocument(views.html.components.HmrcCard(model, "h4")(messages).toString)
+
+      doc.select("h4.hmrc-card__heading").size mustBe 1
+      doc.select("h4.hmrc-card__heading").text mustBe "Test Heading"
+      doc.select("h3.hmrc-card__heading").size mustBe 0
+    }
+    "throw error for invalid heading level" in {
+      val model = HmrcCardModel(CardType.BasicCard, CardHeading("Test Heading", Some("/test"), false), None, None)
+
+      an[IllegalArgumentException] must be thrownBy
+        views.html.components.HmrcCard(model, "h7")(messages).toString
+    }
     "render arbitrary html in BasicCardWithDueDate correctly, without characters escaping" in {
       val model = HmrcCardModel(
         CardType.BasicCardWithDueDate,

--- a/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
+++ b/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
@@ -102,6 +102,14 @@ class TaxesAndBenefitsViewSpec extends ViewSpec {
       document.select("h3#other-services-heading").text() mustBe messages("label.other_taxes_and_benefits_heading")
     }
 
+    "render service card headings as h4 under the h3 section headings" in {
+      val document: Document = asDocument(page(Seq(payeService), Seq(childBenefitService)).toString)
+      document.select("h4.hmrc-card__heading").size() mustBe 2
+      document.select("h4.hmrc-card__heading").get(0).text() mustBe "Pay As You Earn (PAYE)"
+      document.select("h4.hmrc-card__heading").get(1).text() mustBe "Child Benefit"
+      document.select("div.hmrc-card h3.hmrc-card__heading").size() mustBe 0
+    }
+
     "add top margin spacing to the 'Other taxes and benefits' heading" in {
       val document: Document = asDocument(page(Seq(payeService), Seq(childBenefitService)).toString)
       document.select("h3#other-services-heading").hasClass("govuk-!-margin-top-5") mustBe true

--- a/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
+++ b/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
@@ -76,20 +76,35 @@ class TaxesAndBenefitsViewSpec extends ViewSpec {
 
   "TaxesAndBenefitsView" must {
 
-    "render the 'Your current HMRC Online taxes and benefits' heading when myServices are present" in {
-      val document: Document = asDocument(page(Seq(payeService), Seq.empty).toString)
-      document.select("h2#my-services-heading").text() mustBe messages("label.taxes_and_benefits_subheading")
+    "render the 'Taxes and benefits' tab heading as an h2" in {
+      val document: Document = asDocument(page(Seq(payeService), Seq(childBenefitService)).toString)
+      document.select("h2#taxes-and-benefits-tab-heading").text() mustBe messages("label.taxes_and_benefits_heading")
     }
 
-    "render the 'Other taxes and benefits' heading when otherServices are present" in {
+    "render the 'Taxes and benefits' tab heading even when both services are empty" in {
+      val document: Document = asDocument(page(Seq.empty, Seq.empty).toString)
+      document.select("h2#taxes-and-benefits-tab-heading").text() mustBe messages("label.taxes_and_benefits_heading")
+    }
+
+    "render the 'Your current HMRC Online taxes and benefits' heading as an h3 when myServices are present" in {
+      val document: Document = asDocument(page(Seq(payeService), Seq.empty).toString)
+      document.select("h3#my-services-heading").text() mustBe messages("label.taxes_and_benefits_subheading")
+    }
+
+    "render the 'Other taxes and benefits' heading as an h3 when otherServices are present" in {
       val document: Document = asDocument(page(Seq.empty, Seq(childBenefitService)).toString)
-      document.select("h2#other-services-heading").text() mustBe messages("label.other_taxes_and_benefits_heading")
+      document.select("h3#other-services-heading").text() mustBe messages("label.other_taxes_and_benefits_heading")
     }
 
     "render both section headings when both myServices and otherServices are present" in {
       val document: Document = asDocument(page(Seq(payeService), Seq(childBenefitService)).toString)
-      document.select("h2#my-services-heading").text() mustBe messages("label.taxes_and_benefits_subheading")
-      document.select("h2#other-services-heading").text() mustBe messages("label.other_taxes_and_benefits_heading")
+      document.select("h3#my-services-heading").text() mustBe messages("label.taxes_and_benefits_subheading")
+      document.select("h3#other-services-heading").text() mustBe messages("label.other_taxes_and_benefits_heading")
+    }
+
+    "add top margin spacing to the 'Other taxes and benefits' heading" in {
+      val document: Document = asDocument(page(Seq(payeService), Seq(childBenefitService)).toString)
+      document.select("h3#other-services-heading").hasClass("govuk-!-margin-top-5") mustBe true
     }
 
     "render myService cards with correct links" in {
@@ -110,17 +125,17 @@ class TaxesAndBenefitsViewSpec extends ViewSpec {
 
     "not render 'my services' heading when myServices is empty" in {
       val document: Document = asDocument(page(Seq.empty, Seq(childBenefitService)).toString)
-      document.select("h2#my-services-heading").size() mustBe 0
+      document.select("h3#my-services-heading").size() mustBe 0
     }
 
     "not render 'other services' heading when otherServices is empty" in {
       val document: Document = asDocument(page(Seq(payeService), Seq.empty).toString)
-      document.select("h2#other-services-heading").size() mustBe 0
+      document.select("h3#other-services-heading").size() mustBe 0
     }
 
-    "render no cards and no headings when both services are empty" in {
+    "render no cards and no section headings when both services are empty" in {
       val document: Document = asDocument(page(Seq.empty, Seq.empty).toString)
-      document.select("h2").size() mustBe 0
+      document.select("h3").size() mustBe 0
       document.select("div.hmrc-card").size() mustBe 0
     }
 
@@ -134,8 +149,11 @@ class TaxesAndBenefitsViewSpec extends ViewSpec {
 
     "render Welsh section headings when viewed in Welsh" in {
       val welshDoc: Document = asDocument(page(Seq(payeService), Seq(childBenefitService))(welshMessages).toString)
-      welshDoc.select("h2#my-services-heading").text() mustBe welshMessages("label.taxes_and_benefits_subheading")
-      welshDoc.select("h2#other-services-heading").text() mustBe welshMessages("label.other_taxes_and_benefits_heading")
+      welshDoc.select("h2#taxes-and-benefits-tab-heading").text() mustBe welshMessages(
+        "label.taxes_and_benefits_heading"
+      )
+      welshDoc.select("h3#my-services-heading").text() mustBe welshMessages("label.taxes_and_benefits_subheading")
+      welshDoc.select("h3#other-services-heading").text() mustBe welshMessages("label.other_taxes_and_benefits_heading")
     }
 
     "use aria-labelledby on card containers referencing section headings" in {

--- a/test/views/html/tags/CardContainerSpec.scala
+++ b/test/views/html/tags/CardContainerSpec.scala
@@ -200,6 +200,18 @@ class CardContainerSpec extends ViewSpec {
       heading.hasClass("govuk-heading-m") mustBe false
     }
 
+    "render cards with configured heading level" in {
+      val model = CardContainerModel(
+        emptyView = Html(""),
+        header = Some("Test Header"),
+        cardHeadingLevel = "h4",
+        cards = Seq(cardOne)
+      )
+      val doc   = asDocument(cardContainer(model).toString)
+      doc.select("h4.hmrc-card__heading").text() mustBe "Card 1"
+      doc.select("h3.hmrc-card__heading").size() mustBe 0
+    }
+
     "ignore blank header classes and use the default" in {
       val model = CardContainerModel(
         emptyView = Html(""),
@@ -253,6 +265,15 @@ class CardContainerSpec extends ViewSpec {
         CardContainerModel(
           emptyView = Html(""),
           headingLevel = "h7",
+          cards = Seq(cardOne)
+        )
+    }
+
+    "throw error for invalid card heading level" in {
+      an[IllegalArgumentException] must be thrownBy
+        CardContainerModel(
+          emptyView = Html(""),
+          cardHeadingLevel = "h7",
           cards = Seq(cardOne)
         )
     }

--- a/test/views/html/tags/CardContainerSpec.scala
+++ b/test/views/html/tags/CardContainerSpec.scala
@@ -185,6 +185,32 @@ class CardContainerSpec extends ViewSpec {
       doc.select("h3.govuk-heading-m").text() mustBe "Test Header"
     }
 
+    "render configured header classes in place of the default" in {
+      val model   = CardContainerModel(
+        emptyView = Html(""),
+        header = Some("Test Header"),
+        headingLevel = "h3",
+        headerClasses = Some("govuk-heading-s govuk-!-margin-top-5"),
+        cards = Seq(cardOne)
+      )
+      val doc     = asDocument(cardContainer(model).toString)
+      val heading = doc.select("h3.govuk-heading-s")
+      heading.text() mustBe "Test Header"
+      heading.hasClass("govuk-!-margin-top-5") mustBe true
+      heading.hasClass("govuk-heading-m") mustBe false
+    }
+
+    "ignore blank header classes and use the default" in {
+      val model = CardContainerModel(
+        emptyView = Html(""),
+        header = Some("Test Header"),
+        headerClasses = Some("   "),
+        cards = Seq(cardOne)
+      )
+      val doc   = asDocument(cardContainer(model).toString)
+      doc.select("h2.govuk-heading-m").text() mustBe "Test Header"
+    }
+
     "render an HTML header when provided" in {
       val model = CardContainerModel(
         emptyView = Html(""),


### PR DESCRIPTION
- Adds the missing `Taxes and benefits` H2 heading to the Taxes and benefits tab.
- Changes the existing Taxes and benefits section headings from H2 to H3.
- Adds `govuk-!-margin-top-5` spacing to the “Other taxes and benefits” heading.
- Updates view/controller specs for the new heading hierarchy and spacing.