### PR TITLE
PTAD-214: Private Beta - Tabular design - Fix Welsh translation for content headers in Your Tasks and Recent Activity tabs

### DIFF
--- a/app/viewmodels/PtapHomeViewModel.scala
+++ b/app/viewmodels/PtapHomeViewModel.scala
@@ -21,9 +21,9 @@ import views.html.components.TabDefaultInsetText
 import play.api.i18n.Messages
 import play.twirl.api.Html
 
-enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
-  case Task extends TabEnum("your-tasks", Some("Your tasks"))
-  case Activity extends TabEnum("recent-activity", Some("Recent activity"))
+enum TabEnum(val name: String):
+  case Task extends TabEnum("your-tasks")
+  case Activity extends TabEnum("recent-activity")
   case Tax extends TabEnum("taxes-and-benefits")
   case News extends TabEnum("hmrc-news")
   case Support extends TabEnum("support")

--- a/app/viewmodels/PtapHomeViewModel.scala
+++ b/app/viewmodels/PtapHomeViewModel.scala
@@ -37,6 +37,11 @@ enum TabEnum(val name: String, val cardContainerHeading: Option[String] = None):
   }
   def defaultInset(query: Option[String])(implicit messages: Messages): Html =
     TabDefaultInsetText(this, query)
+  def cardContainerHeading(implicit messages: Messages): Option[String]      =
+    this match
+      case Task     => Some(messages("ptap.support.uya.p2.sub"))
+      case Activity => Some(messages("ptap.support.uya.p3.sub"))
+      case _        => None
 
 final case class PtapAlertBanner(content: Html) extends AnyVal
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -899,7 +899,7 @@ ptap.support.uya.p2.tasks=TBC
 ptap.support.uya.p2.tasks.list=TBC
 ptap.support.uya.p2.tasks.list.other=TBC
 
-ptap.support.uya.p3.sub=TBC
+ptap.support.uya.p3.sub=Gweithgarwch diweddar
 ptap.support.uya.p3.recent=TBC
 
 ptap.support.uya.p4.sub=Trethi a budd-daliadau


### PR DESCRIPTION
Ticket: [PTAD-214](https://jira.tools.tax.service.gov.uk/browse/PTAD-214)

- refactored TabEnum, removing the parameter cardContainerHeading and replacing it with a method of the same name, which uses messages to return the correct local translation
- added welsh content for *"Recent activity"* heading 