### PR TITLE
PTAD-216: Private Beta - Implement missing hint text for Taxes and Benefits service links

### DIFF
--- a/app/services/HomePageServicesProvider.scala
+++ b/app/services/HomePageServicesProvider.scala
@@ -68,7 +68,7 @@ class HomePageServicesProvider @Inject() (
       payAsYouEarn        <- getPayAsYouEarn(isRedesign)
       taxCalc             <- getTaxCalculation(isTrustedHelperUser, isRedesign)
       nationalInsurance   <- getNationalInsurance(isRedesign)
-      selfAssessmentOther <- getOtherSelfAssessment(request.saUserType, isTrustedHelperUser, isRedesign)
+      selfAssessmentOther <- getOtherSelfAssessment(request.saUserType, isTrustedHelperUser)
       mtdOther            <- getMtdOtherService(isTrustedHelperUser, isRedesign)
       childBenefit        <- getChildBenefit(isTrustedHelperUser, isRedesign)
       annualTaxSummary    <- getAnnualTaxSummaries(isTrustedHelperUser, isRedesign)
@@ -101,28 +101,23 @@ class HomePageServicesProvider @Inject() (
       id = Some("itsa")
     )
 
-  private def mySaTile(href: String, body: String, isRedesign: Boolean)(implicit messages: Messages): MyService =
+  private def mySaTile(href: String, body: String)(implicit messages: Messages): MyService =
     MyService(
       messages("label.self_assessment"),
       Some(href),
-      Option(body)
-        .filter(_.nonEmpty)
-        .orElse(redesignHint(isRedesign, "label.view_and_manage_your_income_tax_obligations_and_payments")),
+      Option(body).filter(_.nonEmpty),
       gaAction = Some("Income"),
       gaLabel = Some("Self Assessment"),
       id = Some("self-assessment")
     )
 
-  private def otherSaTile(title: String, linkUrl: String, isRedesign: Boolean)(implicit
-    messages: Messages
-  ): OtherService =
+  private def otherSaTile(title: String, linkUrl: String): OtherService =
     OtherService(
       title,
       linkUrl,
       gaAction = Some("Income"),
       gaLabel = Some("Self Assessment"),
-      id = Some("self-assessment"),
-      hintText = redesignHint(isRedesign, "label.view_and_manage_your_income_tax_obligations_and_payments")
+      id = Some("self-assessment")
     )
 
   private def mtdTile(linkUrl: String, isRedesign: Boolean)(implicit messages: Messages): OtherService =
@@ -132,7 +127,7 @@ class HomePageServicesProvider @Inject() (
       gaAction = Some("MTDIT"),
       gaLabel = Some("Making Tax Digital for Income Tax"),
       id = Some("mtdit"),
-      hintText = redesignHint(isRedesign, "label.view_and_manage_your_income_tax_obligations_and_payments")
+      hintText = redesignHint(isRedesign, "label.mtdit.p1")
     )
 
   private def getMySelfAssessment(
@@ -168,8 +163,7 @@ class HomePageServicesProvider @Inject() (
             Some(
               mySaTile(
                 href = controllers.interstitials.routes.InterstitialController.displaySelfAssessment.url,
-                body = "",
-                isRedesign = isRedesign
+                body = ""
               )
             )
 
@@ -177,8 +171,7 @@ class HomePageServicesProvider @Inject() (
             Some(
               mySaTile(
                 href = controllers.routes.SaWrongCredentialsController.landingPage().url,
-                body = messages("title.signed_in_wrong_account.h1"),
-                isRedesign = isRedesign
+                body = messages("title.signed_in_wrong_account.h1")
               )
             )
 
@@ -190,8 +183,7 @@ class HomePageServicesProvider @Inject() (
 
   private def getOtherSelfAssessment(
     saUserType: SelfAssessmentUserType,
-    isTrustedHelperUser: Boolean,
-    isRedesign: Boolean
+    isTrustedHelperUser: Boolean
   )(implicit messages: Messages): Future[Option[OtherService]] =
     Future.successful {
       if (isTrustedHelperUser) {
@@ -202,8 +194,7 @@ class HomePageServicesProvider @Inject() (
             Some(
               otherSaTile(
                 title = messages("label.self_assessment"),
-                linkUrl = controllers.routes.SelfAssessmentController.requestAccess.url,
-                isRedesign = isRedesign
+                linkUrl = controllers.routes.SelfAssessmentController.requestAccess.url
               )
             )
 
@@ -211,8 +202,7 @@ class HomePageServicesProvider @Inject() (
             Some(
               otherSaTile(
                 title = messages("label.self_assessment"),
-                linkUrl = configDecorator.ssoToActivateSaEnrolmentPinUrl,
-                isRedesign = isRedesign
+                linkUrl = configDecorator.ssoToActivateSaEnrolmentPinUrl
               )
             )
 

--- a/app/services/HomePageServicesProvider.scala
+++ b/app/services/HomePageServicesProvider.scala
@@ -64,13 +64,13 @@ class HomePageServicesProvider @Inject() (
       else fandFService.isAnyFandFRelationships(nino).map(buildTrustedHelperServices(_, isRedesign))
 
     for {
-      selfAssessmentMy    <- getMySelfAssessment(request.saUserType, request.enrolments, isTrustedHelperUser)
+      selfAssessmentMy    <- getMySelfAssessment(request.saUserType, request.enrolments, isTrustedHelperUser, isRedesign)
       payAsYouEarn        <- getPayAsYouEarn(isRedesign)
-      taxCalc             <- getTaxCalculation(isTrustedHelperUser)
+      taxCalc             <- getTaxCalculation(isTrustedHelperUser, isRedesign)
       nationalInsurance   <- getNationalInsurance(isRedesign)
-      selfAssessmentOther <- getOtherSelfAssessment(request.saUserType, isTrustedHelperUser)
-      mtdOther            <- getMtdOtherService(isTrustedHelperUser)
-      childBenefit        <- getChildBenefit(isTrustedHelperUser)
+      selfAssessmentOther <- getOtherSelfAssessment(request.saUserType, isTrustedHelperUser, isRedesign)
+      mtdOther            <- getMtdOtherService(isTrustedHelperUser, isRedesign)
+      childBenefit        <- getChildBenefit(isTrustedHelperUser, isRedesign)
       annualTaxSummary    <- getAnnualTaxSummaries(isTrustedHelperUser, isRedesign)
       marriageAllowance   <- marriageAllowanceF
       trustedHelper       <- trustedHelperF
@@ -91,48 +91,55 @@ class HomePageServicesProvider @Inject() (
   private def userHasMtdItsaEnrolment(enrolments: Set[Enrolment]): Boolean =
     enrolments.exists(_.key == MtdItsaEnrolmentKey)
 
-  private def combinedMtdSaTile(href: String)(implicit messages: Messages): MyService =
+  private def combinedMtdSaTile(href: String, isRedesign: Boolean)(implicit messages: Messages): MyService =
     MyService(
       messages("label.mtd_for_itsa"),
       Some(href),
-      None,
+      redesignHint(isRedesign, "label.view_and_manage_your_income_tax_obligations_and_payments"),
       gaAction = Some("Income"),
       gaLabel = Some("MTD IT & SA"),
       id = Some("itsa")
     )
 
-  private def mySaTile(href: String, body: String)(implicit messages: Messages): MyService =
+  private def mySaTile(href: String, body: String, isRedesign: Boolean)(implicit messages: Messages): MyService =
     MyService(
       messages("label.self_assessment"),
       Some(href),
-      Option(body).filter(_.nonEmpty),
+      Option(body)
+        .filter(_.nonEmpty)
+        .orElse(redesignHint(isRedesign, "label.view_and_manage_your_income_tax_obligations_and_payments")),
       gaAction = Some("Income"),
       gaLabel = Some("Self Assessment"),
       id = Some("self-assessment")
     )
 
-  private def otherSaTile(title: String, linkUrl: String): OtherService =
+  private def otherSaTile(title: String, linkUrl: String, isRedesign: Boolean)(implicit
+    messages: Messages
+  ): OtherService =
     OtherService(
       title,
       linkUrl,
       gaAction = Some("Income"),
       gaLabel = Some("Self Assessment"),
-      id = Some("self-assessment")
+      id = Some("self-assessment"),
+      hintText = redesignHint(isRedesign, "label.view_and_manage_your_income_tax_obligations_and_payments")
     )
 
-  private def mtdTile(linkUrl: String)(implicit messages: Messages): OtherService =
+  private def mtdTile(linkUrl: String, isRedesign: Boolean)(implicit messages: Messages): OtherService =
     OtherService(
       messages("label.mtd_for_it"),
       linkUrl,
       gaAction = Some("MTDIT"),
       gaLabel = Some("Making Tax Digital for Income Tax"),
-      id = Some("mtdit")
+      id = Some("mtdit"),
+      hintText = redesignHint(isRedesign, "label.view_and_manage_your_income_tax_obligations_and_payments")
     )
 
   private def getMySelfAssessment(
     saUserType: SelfAssessmentUserType,
     enrolments: Set[Enrolment],
-    isTrustedHelperUser: Boolean
+    isTrustedHelperUser: Boolean,
+    isRedesign: Boolean
   )(implicit messages: Messages): Future[Option[MyService]] =
     Future.successful {
       if (isTrustedHelperUser) {
@@ -144,14 +151,16 @@ class HomePageServicesProvider @Inject() (
           case (_: ActivatedOnlineFilerSelfAssessmentUser, true) =>
             Some(
               combinedMtdSaTile(
-                href = controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url
+                href = controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url,
+                isRedesign = isRedesign
               )
             )
 
           case (WrongCredentialsSelfAssessmentUser(_), true) =>
             Some(
               combinedMtdSaTile(
-                href = controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url
+                href = controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url,
+                isRedesign = isRedesign
               )
             )
 
@@ -159,7 +168,8 @@ class HomePageServicesProvider @Inject() (
             Some(
               mySaTile(
                 href = controllers.interstitials.routes.InterstitialController.displaySelfAssessment.url,
-                body = ""
+                body = "",
+                isRedesign = isRedesign
               )
             )
 
@@ -167,7 +177,8 @@ class HomePageServicesProvider @Inject() (
             Some(
               mySaTile(
                 href = controllers.routes.SaWrongCredentialsController.landingPage().url,
-                body = messages("title.signed_in_wrong_account.h1")
+                body = messages("title.signed_in_wrong_account.h1"),
+                isRedesign = isRedesign
               )
             )
 
@@ -179,7 +190,8 @@ class HomePageServicesProvider @Inject() (
 
   private def getOtherSelfAssessment(
     saUserType: SelfAssessmentUserType,
-    isTrustedHelperUser: Boolean
+    isTrustedHelperUser: Boolean,
+    isRedesign: Boolean
   )(implicit messages: Messages): Future[Option[OtherService]] =
     Future.successful {
       if (isTrustedHelperUser) {
@@ -190,7 +202,8 @@ class HomePageServicesProvider @Inject() (
             Some(
               otherSaTile(
                 title = messages("label.self_assessment"),
-                linkUrl = controllers.routes.SelfAssessmentController.requestAccess.url
+                linkUrl = controllers.routes.SelfAssessmentController.requestAccess.url,
+                isRedesign = isRedesign
               )
             )
 
@@ -198,7 +211,8 @@ class HomePageServicesProvider @Inject() (
             Some(
               otherSaTile(
                 title = messages("label.self_assessment"),
-                linkUrl = configDecorator.ssoToActivateSaEnrolmentPinUrl
+                linkUrl = configDecorator.ssoToActivateSaEnrolmentPinUrl,
+                isRedesign = isRedesign
               )
             )
 
@@ -209,7 +223,8 @@ class HomePageServicesProvider @Inject() (
     }
 
   private def getMtdOtherService(
-    isTrustedHelperUser: Boolean
+    isTrustedHelperUser: Boolean,
+    isRedesign: Boolean
   )(implicit request: UserRequest[?], messages: Messages): Future[Option[OtherService]] =
     if (isTrustedHelperUser) {
       Future.successful(None)
@@ -221,7 +236,8 @@ class HomePageServicesProvider @Inject() (
           Future.successful(
             Some(
               mtdTile(
-                controllers.interstitials.routes.MtdAdvertInterstitialController.displayMTDITPage.url
+                controllers.interstitials.routes.MtdAdvertInterstitialController.displayMTDITPage.url,
+                isRedesign = isRedesign
               )
             )
           )
@@ -243,7 +259,7 @@ class HomePageServicesProvider @Inject() (
       )
     )
 
-  private def getTaxCalculation(isTrustedHelperUser: Boolean)(implicit
+  private def getTaxCalculation(isTrustedHelperUser: Boolean, isRedesign: Boolean)(implicit
     messages: Messages
   ): Future[Option[MyService]] =
     if (isTrustedHelperUser) {
@@ -259,7 +275,10 @@ class HomePageServicesProvider @Inject() (
                 s"${current.startYear}"
               ),
               Some(configDecorator.taxCalcHomePageUrl),
-              None,
+              redesignHint(
+                isRedesign,
+                "label.check_whether_you_paid_too_much_or_too_little_tax_in_a_previous_tax_year"
+              ),
               gaAction = Some("Income"),
               gaLabel = Some("Tax Calculation"),
               id = Some("tax-calc")
@@ -285,7 +304,7 @@ class HomePageServicesProvider @Inject() (
       )
     )
 
-  private def getChildBenefit(isTrustedHelperUser: Boolean)(implicit
+  private def getChildBenefit(isTrustedHelperUser: Boolean, isRedesign: Boolean)(implicit
     messages: Messages
   ): Future[Option[OtherService]] =
     Future.successful {
@@ -298,7 +317,8 @@ class HomePageServicesProvider @Inject() (
             controllers.interstitials.routes.InterstitialController.displayChildBenefitsSingleAccountView.url,
             gaAction = Some("Benefits"),
             gaLabel = Some("Child Benefit"),
-            id = Some("child-benefit")
+            id = Some("child-benefit"),
+            hintText = redesignHint(isRedesign, "label.get_help_with_the_cost_of_bringing_up_children")
           )
         )
       }

--- a/conf/messages
+++ b/conf/messages
@@ -441,6 +441,7 @@ label.you_have_no_payments_to_make_to_hmrc=You have no payments to make to HMRC.
 
 label.self_assessment=Self Assessment
 label.mtd_for_itsa=Making Tax Digital for Income Tax and Self Assessment
+label.view_and_manage_your_income_tax_obligations_and_payments=View and manage your Income Tax obligations and payments.
 label.make_a_payment=Make a payment
 label.check_if_you_need_to_fill_in_a_tax_return=Check if you need to fill in a tax return
 label.find_out_how_to_access_self_assessment=Find out how to access Self Assessment
@@ -539,6 +540,7 @@ label.manage_your_marriage_allowance=Manage your Marriage Allowance
 label.your_partner_currently_transfers_part_of_their_personal_allowance_to_you=Your partner currently transfers part of their Personal Allowance to you.
 label.you_currently_transfer_part_of_your_personal_allowance_to_your_partner=You currently transfer part of your Personal Allowance to your partner.
 label.child_benefit=Child Benefit
+label.get_help_with_the_cost_of_bringing_up_children=Get help with the cost of bringing up children.
 label.make_or_manage_a_child_benefit_claim=Make or manage a Child Benefit claim
 label.make_a_claim=Make a claim
 label.making_a_claim=Making a claim
@@ -846,6 +848,7 @@ label.taxes_and_benefits_subheading=Your current HMRC Online taxes and benefits
 label.other_taxes_and_benefits_heading=Other taxes and benefits that may be relevant to you
 
 label.tax_calc_option=Your tax calculation — PAYE {0} to {1}
+label.check_whether_you_paid_too_much_or_too_little_tax_in_a_previous_tax_year=Check whether you paid too much or too little tax in a previous tax year.
 
 label.task_heading=Refunds and tax you owe — Pay As You Earn (PAYE)
 label.task_paragraph=It can take up to 10 days for completed tasks to be removed from the list.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -192,7 +192,7 @@ label.back_to_account_home=Yn ôl i hafan y cyfrif
 label.return_to_your_account_home=Yn ôl i hafan eich cyfrif
 label.national_insurance_summary=Crynodeb Yswiriant Gwladol
 label.child_benefit=Budd-dal Plant
-label.get_help_with_the_cost_of_bringing_up_children=Get help with the cost of bringing up children.
+label.get_help_with_the_cost_of_bringing_up_children=Cael help gyda chostau magu plant.
 label.report_changes_that_affect_your_child_benefit=Rhoi gwybod am newidiadau sy’n effeithio ar eich Budd-dal Plant
 label.tell_us_your_child_is_staying_in_full_time_education=Rhowch wybod i ni fod eich plentyn yn parhau ag addysg amser llawn
 label.tell_us_if_you_need_to=Rhowch wybod i ni os oes angen i chi:
@@ -820,7 +820,7 @@ tax_credits.ended.information.how.continue.li2 = cysylltu â Gwasanaeth Cwsmeria
 
 label.mtd_for_it=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.mtd_for_itsa=Troi Treth yn Ddigidol ar gyfer Treth Incwm a Hunanasesiad
-label.view_and_manage_your_income_tax_obligations_and_payments=View and manage your Income Tax obligations and payments.
+label.view_and_manage_your_income_tax_obligations_and_payments=Bwrw golwg dros a rheoli’ch rhwymedigaethau a’ch taliadau Treth Incwm.
 label.mtd_for_it_sa=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.send_updates_sole_traders=Ar gyfer unig fasnachwyr a landlordiaid sy’n anfon diweddariadau chwarterol gan ddefnyddio meddalwedd.
 label.view_manage_your_mtd_for_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli
@@ -859,7 +859,7 @@ label.taxes_and_benefits_subheading=Eich trethi a budd-daliadau CThEF ar-lein pr
 label.other_taxes_and_benefits_heading=Trethi a budd-daliadau eraill a allai fod yn berthnasol i chi
 
 label.tax_calc_option=Eich cyfrifiad treth – TWE {0} i {1}
-label.check_whether_you_paid_too_much_or_too_little_tax_in_a_previous_tax_year=Check whether you paid too much or too little tax in a previous tax year.
+label.check_whether_you_paid_too_much_or_too_little_tax_in_a_previous_tax_year=Gwiriwch a wnaethoch dalu gormod neu rhy ychydig o dreth mewn blwyddyn dreth flaenorol.
 
 label.task_heading=Ad-daliadau a’r dreth sydd arnoch – Talu Wrth Ennill (TWE)
 label.task_paragraph=Gall gymryd hyd at 10 diwrnod i’r tasgau sydd wedi’u cwblhau gael eu tynnu o’r rhestr.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -192,6 +192,7 @@ label.back_to_account_home=Yn ôl i hafan y cyfrif
 label.return_to_your_account_home=Yn ôl i hafan eich cyfrif
 label.national_insurance_summary=Crynodeb Yswiriant Gwladol
 label.child_benefit=Budd-dal Plant
+label.get_help_with_the_cost_of_bringing_up_children=Get help with the cost of bringing up children.
 label.report_changes_that_affect_your_child_benefit=Rhoi gwybod am newidiadau sy’n effeithio ar eich Budd-dal Plant
 label.tell_us_your_child_is_staying_in_full_time_education=Rhowch wybod i ni fod eich plentyn yn parhau ag addysg amser llawn
 label.tell_us_if_you_need_to=Rhowch wybod i ni os oes angen i chi:
@@ -819,6 +820,7 @@ tax_credits.ended.information.how.continue.li2 = cysylltu â Gwasanaeth Cwsmeria
 
 label.mtd_for_it=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.mtd_for_itsa=Troi Treth yn Ddigidol ar gyfer Treth Incwm a Hunanasesiad
+label.view_and_manage_your_income_tax_obligations_and_payments=View and manage your Income Tax obligations and payments.
 label.mtd_for_it_sa=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.send_updates_sole_traders=Ar gyfer unig fasnachwyr a landlordiaid sy’n anfon diweddariadau chwarterol gan ddefnyddio meddalwedd.
 label.view_manage_your_mtd_for_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli
@@ -857,6 +859,7 @@ label.taxes_and_benefits_subheading=Eich trethi a budd-daliadau CThEF ar-lein pr
 label.other_taxes_and_benefits_heading=Trethi a budd-daliadau eraill a allai fod yn berthnasol i chi
 
 label.tax_calc_option=Eich cyfrifiad treth – TWE {0} i {1}
+label.check_whether_you_paid_too_much_or_too_little_tax_in_a_previous_tax_year=Check whether you paid too much or too little tax in a previous tax year.
 
 label.task_heading=Ad-daliadau a’r dreth sydd arnoch – Talu Wrth Ennill (TWE)
 label.task_paragraph=Gall gymryd hyd at 10 diwrnod i’r tasgau sydd wedi’u cwblhau gael eu tynnu o’r rhestr.

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -510,10 +510,12 @@ class HomePageServicesProviderSpec extends BaseSpec {
 
       result.myServices.find(_.title == "Pay As You Earn (PAYE)").flatMap(_.hintText) mustBe
         Some(messages("label.your_income_from_employers_and_private_pensions_"))
-      result.myServices.find(_.gaLabel.contains("Tax Calculation")).flatMap(_.hintText) mustBe None
+      result.myServices.find(_.gaLabel.contains("Tax Calculation")).flatMap(_.hintText) mustBe
+        Some(messages("label.check_whether_you_paid_too_much_or_too_little_tax_in_a_previous_tax_year"))
       result.myServices.find(_.title == "National Insurance and State Pension").flatMap(_.hintText) mustBe
         Some(s"${messages("label.view_national_insurance")} ${messages("label.view_state_pension")}")
-      result.otherServices.find(_.title == "Child Benefit").flatMap(_.hintText) mustBe None
+      result.otherServices.find(_.title == "Child Benefit").flatMap(_.hintText) mustBe
+        Some(messages("label.get_help_with_the_cost_of_bringing_up_children"))
       result.otherServices.find(_.title == "Annual Tax Summary").flatMap(_.hintText) mustBe
         Some(messages("card.ats.text"))
       result.otherServices.find(_.title == "Marriage Allowance").flatMap(_.hintText) mustBe
@@ -522,14 +524,16 @@ class HomePageServicesProviderSpec extends BaseSpec {
         Some(messages("label.trusted_helpers_content"))
     }
 
-    "not set unapproved Self Assessment or MTD hints on the redesign" in {
+    "set approved Self Assessment and MTD hints on the redesign" in {
       implicit val request: UserRequest[AnyContent] =
         buildRequest(ActivatedOnlineFilerSelfAssessmentUser(SaUtr("11")))
 
       val result = service.getHomePageServices(isRedesign = true).futureValue
 
-      result.myServices.find(_.title == "Self Assessment").flatMap(_.hintText) mustBe None
-      result.otherServices.find(_.title == messages("label.mtd_for_it")).flatMap(_.hintText) mustBe None
+      result.myServices.find(_.title == "Self Assessment").flatMap(_.hintText) mustBe
+        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments"))
+      result.otherServices.find(_.title == messages("label.mtd_for_it")).flatMap(_.hintText) mustBe
+        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments"))
     }
 
     "not set hintText on services when isRedesign is false" in {

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -524,16 +524,15 @@ class HomePageServicesProviderSpec extends BaseSpec {
         Some(messages("label.trusted_helpers_content"))
     }
 
-    "set approved Self Assessment and MTD hints on the redesign" in {
+    "not set a hint on the standalone Self Assessment link but set the agreed MTD hint on the redesign" in {
       implicit val request: UserRequest[AnyContent] =
         buildRequest(ActivatedOnlineFilerSelfAssessmentUser(SaUtr("11")))
 
       val result = service.getHomePageServices(isRedesign = true).futureValue
 
-      result.myServices.find(_.title == "Self Assessment").flatMap(_.hintText) mustBe
-        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments"))
+      result.myServices.find(_.title == "Self Assessment").flatMap(_.hintText) mustBe None
       result.otherServices.find(_.title == messages("label.mtd_for_it")).flatMap(_.hintText) mustBe
-        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments"))
+        Some(messages("label.mtdit.p1"))
     }
 
     "not set hintText on services when isRedesign is false" in {


### PR DESCRIPTION
* Self Assessment / Making Tax Digital for Income Tax: View and manage your Income Tax obligations and payments.
* Your tax calculation: PAYE 20xx to 20xx: Check whether you paid too much or too little tax in a previous tax year.
* Child Benefit: Get help with the cost of bringing up children.

The Trusted Helpers service already has hint text introduced under PTAD-207 and continues to reuse label.trusted_helpers_content.

Changes

* Added new message keys to conf/messages using the agreed English content.
* Wired the new hints into HomePageServicesProvider using the existing redesignHint pattern. This ensures they are shown only on the private beta/redesign journey while preserving the existing filtering behaviour, including Trusted Helpers suppression and feature-toggle rules.
* Applied the Self Assessment/MTD hint to all relevant service-link variants:
    * Combined Making Tax Digital and Self Assessment tile
    * Standalone Self Assessment tile
    * Standalone Making Tax Digital tile
* Left the existing text for the Self Assessment wrong-credentials tile unchanged.
* Updated the relevant specifications to assert the new hint text.

Welsh translation

A Welsh translation is not required for the private beta, as confirmed in the ticket.

The new keys have still been added to conf/messages.cy using the English text as placeholders. This maintains message-key parity and ensures MessagesSpec continues to pass.

The three placeholder values can be replaced once the approved Welsh translations are provided.