### PR TITLE
PTAD-206: Private Beta - Review and update use of “HMRC Online” wording

### DIFF
--- a/app/controllers/support/SupportController.scala
+++ b/app/controllers/support/SupportController.scala
@@ -17,7 +17,6 @@
 package controllers.support
 
 import com.google.inject.Inject
-import config.ConfigDecorator
 import controllers.PertaxBaseController
 import controllers.auth.AuthJourney
 import controllers.auth.requests.UserRequest
@@ -29,8 +28,6 @@ import scala.concurrent.Future
 class SupportController @Inject (authJourney: AuthJourney)(
   cc: MessagesControllerComponents,
   understandingYourAccountView: UnderstandingYourAccountView
-)(implicit
-  configDecorator: ConfigDecorator
 ) extends PertaxBaseController(cc) {
 
   private val authenticate: ActionBuilder[UserRequest, AnyContent] =

--- a/app/views/support/UnderstandingYourAccountView.scala.html
+++ b/app/views/support/UnderstandingYourAccountView.scala.html
@@ -14,7 +14,6 @@
  * limitations under the License.
  *@
 
-@import config.ConfigDecorator
 @import controllers.auth.requests.UserRequest
 @import tags._
 @import uk.gov.hmrc.domain.Nino
@@ -24,18 +23,16 @@
 @import viewmodels.AlertBannerViewModel
 @import views.MainView
 @import views.html.components.alertBanner.AlertBanner
-@import views.html.components.{H1, H2, H3, Link, P}
+@import views.html.components.{H1, H2, Link, P}
 
 @this(
         main: MainView,
         h1: H1,
         h2: H2,
-        h3: H3,
-        p: P,
-        link: Link
+        p: P
 )
 
-@()(implicit request: UserRequest[_], configDecorator: ConfigDecorator, messages: play.api.i18n.Messages)
+@()(implicit request: UserRequest[_], messages: play.api.i18n.Messages)
 
 @main(
     pageTitle = messages("ptap.support.uya.title"),
@@ -44,57 +41,27 @@
     @h1("ptap.support.uya.title")
 
     @p(Text(messages("ptap.support.uya.p1")))
-    @p(Text(messages("ptap.support.uya.p1.list")))
 
     <ul class="govuk-list govuk-list--bullet" id="accessList">
-        <li>@messages("ptap.support.uya.list.paye")</li>
-        <li>@messages("ptap.support.uya.list.sa")</li>
-        <li>@messages("ptap.support.uya.list.ni")</li>
-        <li>@messages("ptap.support.uya.list.ats")</li>
-        <li>@messages("ptap.support.uya.list.cb")</li>
-        <li>@messages("ptap.support.uya.list.ma")</li>
+        <li>@messages("ptap.support.uya.p4.sub")</li>
+        <li>@messages("ptap.support.uya.p2.sub")</li>
+        <li>@messages("ptap.support.uya.p5.sub")</li>
+        <li>@messages("ptap.support.uya.p6.sub")</li>
     </ul>
-
-    @h2("ptap.support.uya.p2.header")
-    <p class="govuk-body">
-        @messages("ptap.support.uya.p2")
-        @link(configDecorator.personalAccount, messageKey = "ptap.support.uya.p2.link", id = Some("personalAccountLink"), inParagraph = true)
-    </p>
-
-    @h3("ptap.support.uya.p2.sub")
-
-    @p(Text(messages("ptap.support.uya.p2.tasks")))
-
-    @p(Text(messages("ptap.support.uya.p2.tasks.list")))
-
-    <ul class="govuk-list govuk-list--bullet" id="taskList">
-        <li>@messages("ptap.support.uya.list.paye")</li>
-        <li>@messages("ptap.support.uya.list.sa")</li>
-        <li>@messages("ptap.support.uya.list.ni")</li>
-        <li>@messages("ptap.support.uya.list.cb")</li>
-    </ul>
-
-    @p(Text(messages("ptap.support.uya.p2.tasks.list.other")))
-
-    <ul class="govuk-list govuk-list--bullet" id="otherList">
-        <li>@messages("ptap.support.uya.list.uos")</li>
-        <li>@link(configDecorator.notifyChangeOfDetails, messageKey = "ptap.support.uya.list.circumstances.link", id = Some("notifyChangeOfDetailsLink"), inParagraph = true)</li>
-        <li>@messages("ptap.support.uya.list.bta")</li>
-    </ul>
-
-    @h3("ptap.support.uya.p3.sub")
-
-    @p(Text(messages("ptap.support.uya.p3.recent")))
-
-    @h3("ptap.support.uya.p4.sub")
+   
+    @h2("ptap.support.uya.p4.sub")
 
     @p(Text(messages("ptap.support.uya.p4.tab")))
 
-    @h3("ptap.support.uya.p5.sub")
+    @h2("ptap.support.uya.p2.sub")
+
+    @p(Text(messages("ptap.support.uya.p2.tasks")))
+
+    @h2("ptap.support.uya.p5.sub")
 
     @p(Text(messages("ptap.support.uya.p5.hs")))
 
-    @h3("ptap.support.uya.p6.sub")
+    @h2("ptap.support.uya.p6.sub")
 
     @p(Text(messages("ptap.support.uya.p6.hs")))
 }

--- a/conf/messages
+++ b/conf/messages
@@ -874,18 +874,15 @@ ptap.recent-activity.container.default_text.p.line1=This page shows your recent 
 ptap.recent-activity.container.default_text.p.line2.2=Your tasks
 ptap.recent-activity.container.default_text.p.line2.3=for anything you need to do.
 
-ptap.support.uya.title=Understanding your HMRC Online account
-ptap.support.uya.p1=Your HMRC Online account lets you manage your taxes and benefits in one place.
-ptap.support.uya.p1.list=You can use it to access:
+ptap.support.uya.title=Understanding your personal tax account
+ptap.support.uya.p1=Your personal tax account lets you manage your taxes and benefits in one place. You can use your account to access:
 
 ptap.support.uya.p2.header=How to use your HMRC Online account
 ptap.support.uya.p2=Use your HMRC Online account by selecting the following sections within your
 ptap.support.uya.p2.link=Personal tax account.
 
 ptap.support.uya.p2.sub=Your tasks
-ptap.support.uya.p2.tasks=Complete tasks, such as claiming a refund or paying a tax bill.
-ptap.support.uya.p2.tasks.list=You’ll only see tasks for:
-ptap.support.uya.p2.tasks.list.other=You may have other tasks if:
+ptap.support.uya.p2.tasks=Complete tasks such as claiming a refund or paying tax you owe. This section only shows your Pay As You Earn (PAYE) related tasks.
 
 ptap.support.uya.p3.sub=Recent activity
 ptap.support.uya.p3.recent=View recent updates, such as payments from your employer or changes to your tax code.
@@ -894,7 +891,7 @@ ptap.support.uya.p4.sub=Taxes and benefits
 ptap.support.uya.p4.tab=Check the taxes and benefits you currently have and find others that may be relevant to you.
 
 ptap.support.uya.p5.sub=HMRC news
-ptap.support.uya.p5.hs=Read the latest updates and announcements from HMRC.
+ptap.support.uya.p5.hs=Read the latest updates from HMRC.
 
 ptap.support.uya.p6.sub= Support
 ptap.support.uya.p6.hs=Get technical support and help with taxes and benefits.
@@ -919,7 +916,7 @@ ptap.support.tab.card.annual.tax.summary.heading=Annual Tax Summary
 ptap.support.tab.card.insurance.state.pension.heading=National Insurance and State Pension
 ptap.support.tab.cards.header=Support
 
-ptap.support.tab.card.hmrc.online.link.understanding.account=Understanding your HMRC Online account
+ptap.support.tab.card.hmrc.online.link.understanding.account=Understanding your personal tax account
 ptap.support.tab.card.hmrc.online.link.understanding.account.url=/support/understanding-your-account
 ptap.support.tab.card.hmrc.online.link.extra.support=Get help from HMRC if you need extra support
 ptap.support.tab.card.hmrc.online.link.extra.support.url=https://www.gov.uk/get-help-hmrc-extra-support

--- a/conf/messages
+++ b/conf/messages
@@ -907,7 +907,7 @@ ptap.support.uya.list.uos=you use other HMRC services
 ptap.support.uya.list.circumstances.link=your circumstances change (opens in new tab)
 ptap.support.uya.list.bta=you have a Business Tax Account
 
-ptap.support.tab.card.hmrc.online.heading=HMRC Online
+ptap.support.tab.card.hmrc.online.heading=Personal tax account
 ptap.support.tab.card.paye.heading=Pay As You Earn (PAYE)
 ptap.support.tab.card.self.assessment.heading=Self Assessment
 ptap.support.tab.card.child.benefit.heading=Child Benefit

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -888,7 +888,6 @@ ptap.recent-activity.container.default_text.p.line2.3=am unrhyw beth arall rydyc
 
 ptap.support.uya.title=TBC
 ptap.support.uya.p1=TBC
-ptap.support.uya.p1.list=TBC
 
 ptap.support.uya.p2.header=TBC
 ptap.support.uya.p2=TBC

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -896,8 +896,6 @@ ptap.support.uya.p2.link=TBC
 
 ptap.support.uya.p2.sub=Eich tasgau
 ptap.support.uya.p2.tasks=TBC
-ptap.support.uya.p2.tasks.list=TBC
-ptap.support.uya.p2.tasks.list.other=TBC
 
 ptap.support.uya.p3.sub=Gweithgarwch diweddar
 ptap.support.uya.p3.recent=TBC

--- a/test/views/html/support/UnderstandingYourAccountViewSpec.scala
+++ b/test/views/html/support/UnderstandingYourAccountViewSpec.scala
@@ -58,94 +58,51 @@ class UnderstandingYourAccountViewSpec extends ViewSpec {
   "Rendering UnderstandingYourAccountView.scala.html" must {
     lazy val document: Document = asDocument(page().toString)
 
-    "show the expected title for Understanding your HMRC Online account page" in {
-      document.select("title").asScala.exists(e => e.text contains "Understanding your HMRC Online account") mustBe true
+    "show the expected title and content for Understanding your personal tax account page" in {
+      val title = document.select("h1").asScala
+
+      title.exists(e => e.text contains "Understanding your personal tax account") mustBe true
+
     }
 
-    "show the expected headers for Understanding your HMRC Online account page" in {
-      document.select("h1").asScala.exists(e => e.text == "Understanding your HMRC Online account") mustBe true
-      document.select("h2").asScala.exists(e => e.text == "How to use your HMRC Online account") mustBe true
+    "show the expected list content  for the access list section" in {
+      val list = document.select("ul[id*='accessList']").select("li").asScala
 
-      val h3s = document.select("h3").asScala
-      h3s.exists(e => e.text == "Your tasks")
-      h3s.exists(e => e.text == "Recent activity")
-      h3s.exists(e => e.text == "Taxes and benefits")
-      h3s.exists(e => e.text == "HMRC news")
-      h3s.exists(e => e.text == "HMRC support")
+      list.exists(e => e.text contains "Taxes and benefits") mustBe true
+      list.exists(e => e.text contains "Your tasks") mustBe true
+      list.exists(e => e.text contains "HMRC news") mustBe true
+      list.exists(e => e.text contains "Support") mustBe true
+      list.size mustBe 4
     }
 
-    "show the expected paragraphs" in {
-      val paragraphs = document.select("p").asScala
+    "show the expected headers for Understanding your personal tax account page" in {
+      val h2s = document.select("div.govuk-grid-column-two-thirds").select("h2").asScala
+      h2s.exists(e => e.text == "Taxes and benefits")
+      h2s.exists(e => e.text == "Your tasks")
+      h2s.exists(e => e.text == "HMRC news")
+      h2s.exists(e => e.text == "Support")
+      h2s.size mustBe 4
+    }
+
+    "show the expected paragraphs for Understanding your personal account page" in {
+      val paragraphs = document.select("div.govuk-grid-column-two-thirds").select("p.govuk-body").asScala
 
       paragraphs.exists(e =>
-        e.text contains "Use your HMRC Online account by selecting the following sections within your"
-      ) mustBe true
-      paragraphs.exists(e => e.text contains "Personal tax account.") mustBe true
-
-      paragraphs.exists(e =>
-        e.text contains "Complete tasks, such as claiming a refund or paying a tax bill."
-      ) mustBe true
-      paragraphs.exists(e => e.text contains "You’ll only see tasks for:") mustBe true
-      paragraphs.exists(e => e.text contains "You may have other tasks if:") mustBe true
-      paragraphs.exists(e =>
-        e.text contains "View recent updates, such as payments from your employer or changes to your tax code."
+        e.text contains "Your personal tax account lets you manage your taxes and benefits in one place. You can use your account to access:"
       ) mustBe true
       paragraphs.exists(e =>
         e.text contains "Check the taxes and benefits you currently have and find others that may be relevant to you."
       ) mustBe true
-      paragraphs.exists(e => e.text contains "Read the latest updates and announcements from HMRC.") mustBe true
+      paragraphs.exists(e =>
+        e.text contains "Complete tasks such as claiming a refund or paying tax you owe. This section only shows your Pay As You Earn (PAYE) related tasks."
+      ) mustBe true
+      paragraphs.exists(e => e.text contains "Read the latest updates from HMRC.") mustBe true
       paragraphs.exists(e => e.text contains "Get technical support and help with taxes and benefits.") mustBe true
-    }
-
-    "show the expected content for the access list" in {
-      val list = document.select("ul[id*='accessList']").select("li").asScala
-      list.size mustBe 6
-
-      list.exists(e => e.text contains "Pay As You Earn (PAYE)") mustBe true
-      list.exists(e => e.text contains "Self Assessment") mustBe true
-      list.exists(e => e.text contains "National Insurance and State Pension") mustBe true
-      list.exists(e => e.text contains "Annual Tax Summary") mustBe true
-      list.exists(e => e.text contains "Child Benefit") mustBe true
-      list.exists(e => e.text contains "Marriage Allowance") mustBe true
-    }
-
-    "show the expected content for the task list" in {
-      val list = document.select("ul[id*='taskList']").select("li").asScala
-      list.size mustBe 4
-
-      list.exists(e => e.text contains "Pay As You Earn (PAYE)") mustBe true
-      list.exists(e => e.text contains "Self Assessment") mustBe true
-      list.exists(e => e.text contains "National Insurance and State Pension") mustBe true
-      list.exists(e => e.text contains "Child Benefit") mustBe true
-    }
-
-    "show the expected content for the other list" in {
-      val list = document.select("ul[id*='otherList']").select("li").asScala
-      list.size mustBe 3
-
-      list.exists(e => e.text contains "you use other HMRC services") mustBe true
-      list.exists(e => e.text contains "your circumstances change (opens in new tab)") mustBe true
-      list.exists(e => e.text contains "you have a Business Tax Account") mustBe true
-    }
-
-    "show the expected content for the personal account link" in {
-      val link = document.select("a[id*='personalAccountLink']").asScala
-
-      link.exists(e => e.attribute("href").getValue == "/personal-account") mustBe true
-      link.exists(e => e.text contains "Personal tax account.") mustBe true
-    }
-
-    "show the expected content for the notify change of details link" in {
-      val link = document.select("a[id*='notifyChangeOfDetailsLink']").asScala
-
-      link.exists(e => e.attribute("href").getValue == "/notify-changes-of-details") mustBe true
-      link.exists(e => e.text contains "your circumstances change (opens in new tab)") mustBe true
+      paragraphs.size mustBe 5
     }
 
     "show the expected content for the back link" in {
       val link = document.select("a[id*='menu.back']").asScala
-
-      println(link)
 
       link.exists(e => e.attribute("href").getValue == "#") mustBe true
       link.exists(e => e.text contains "Back") mustBe true


### PR DESCRIPTION
Ticket: [PTAD-206](https://jira.tools.tax.service.gov.uk/browse/PTAD-206)

- Updated content on Support page and the _Understanding your personal tax account_ page to refer to _personal tax account_ instead of _HMRC online account_.
- content on _Understanding your personal tax account_ page updated to match current prototype.
- UnderstandingYourSupportViewSpec updated to match the new page content.