### PR TITLE
PTAD-231 : Update combined SA and MTD IT label order

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -104,7 +104,7 @@ class HomeController @Inject() (
         val fEitherPersonDetails     = citizenDetailsService.personDetails(nino).value
         val fTabContentCards         = tabContentService.getTaskAndTabCards(currentTab)
         val fHomePageServices        =
-          if (currentTab == Tax) homePageServicesProvider.getHomePageServices()
+          if (currentTab == Tax) homePageServicesProvider.getHomePageServices(isRedesign = true)
           else Future.successful(HomePageServices(Seq.empty))
         val fActivityTabEnabled      = featureFlagService.get(PtapActivityTabToggle).map(_.isEnabled)
 

--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -104,7 +104,7 @@ class HomeController @Inject() (
         val fEitherPersonDetails     = citizenDetailsService.personDetails(nino).value
         val fTabContentCards         = tabContentService.getTaskAndTabCards(currentTab)
         val fHomePageServices        =
-          if (currentTab == Tax) homePageServicesProvider.getHomePageServices(isRedesign = true)
+          if (currentTab == Tax) homePageServicesProvider.getHomePageServices()
           else Future.successful(HomePageServices(Seq.empty))
         val fActivityTabEnabled      = featureFlagService.get(PtapActivityTabToggle).map(_.isEnabled)
 

--- a/app/services/HomePageServicesProvider.scala
+++ b/app/services/HomePageServicesProvider.scala
@@ -95,10 +95,7 @@ class HomePageServicesProvider @Inject() (
     MyService(
       messages("label.mtd_for_itsa"),
       Some(href),
-      redesignHint(
-        isRedesign,
-        s"${messages("label.view_manage_your_mtd_it")} ${messages("label.online_deadline_tax_returns", (current.currentYear + 1).toString)}"
-      ),
+      redesignHint(isRedesign, messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
       gaAction = Some("Income"),
       gaLabel = Some("MTD IT & SA"),
       id = Some("itsa")

--- a/app/services/HomePageServicesProvider.scala
+++ b/app/services/HomePageServicesProvider.scala
@@ -40,13 +40,7 @@ class HomePageServicesProvider @Inject() (
 
   private val MtdItsaEnrolmentKey = "HMRC-MTD-IT"
 
-  private def redesignHint(isRedesign: Boolean, hint: String): Option[String] =
-    Option.when(isRedesign)(hint)
-
-  private def nationalInsuranceHint(isRedesign: Boolean)(implicit messages: Messages): Option[String] =
-    Option.when(isRedesign)(s"${messages("label.view_national_insurance")} ${messages("label.view_state_pension")}")
-
-  def getHomePageServices(isRedesign: Boolean = false)(implicit
+  def getHomePageServices()(implicit
     request: UserRequest[?],
     hc: HeaderCarrier,
     messages: Messages
@@ -57,21 +51,21 @@ class HomePageServicesProvider @Inject() (
 
     val marriageAllowanceF: Future[Seq[HomePageService]] =
       if (isTrustedHelperUser) Future.successful(Seq.empty)
-      else taiService.getTaxComponentsList(nino, current.currentYear).map(buildMarriageAllowanceServices(_, isRedesign))
+      else taiService.getTaxComponentsList(nino, current.currentYear).map(buildMarriageAllowanceServices(_))
 
     val trustedHelperF: Future[Seq[HomePageService]] =
       if (isTrustedHelperUser) Future.successful(Seq.empty)
-      else fandFService.isAnyFandFRelationships(nino).map(buildTrustedHelperServices(_, isRedesign))
+      else fandFService.isAnyFandFRelationships(nino).map(buildTrustedHelperServices(_))
 
     for {
       selfAssessmentMy    <- getMySelfAssessment(request.saUserType, request.enrolments, isTrustedHelperUser)
-      payAsYouEarn        <- getPayAsYouEarn(isRedesign)
-      taxCalc             <- getTaxCalculation(isTrustedHelperUser, isRedesign)
-      nationalInsurance   <- getNationalInsurance(isRedesign)
+      payAsYouEarn        <- getPayAsYouEarn()
+      taxCalc             <- getTaxCalculation(isTrustedHelperUser)
+      nationalInsurance   <- getNationalInsurance()
       selfAssessmentOther <- getOtherSelfAssessment(request.saUserType, isTrustedHelperUser)
       mtdOther            <- getMtdOtherService(isTrustedHelperUser)
-      childBenefit        <- getChildBenefit(isTrustedHelperUser, isRedesign)
-      annualTaxSummary    <- getAnnualTaxSummaries(isTrustedHelperUser, isRedesign)
+      childBenefit        <- getChildBenefit(isTrustedHelperUser)
+      annualTaxSummary    <- getAnnualTaxSummaries(isTrustedHelperUser)
       marriageAllowance   <- marriageAllowanceF
       trustedHelper       <- trustedHelperF
     } yield HomePageServices(
@@ -233,13 +227,13 @@ class HomePageServicesProvider @Inject() (
       }
     }
 
-  private def getPayAsYouEarn(isRedesign: Boolean)(implicit messages: Messages): Future[Option[MyService]] =
+  private def getPayAsYouEarn()(implicit messages: Messages): Future[Option[MyService]] =
     Future.successful(
       Some(
         MyService(
           messages("label.pay_as_you_earn_paye"),
           Some(controllers.routes.RedirectToPayeController.redirectToPaye.url),
-          redesignHint(isRedesign, messages("label.your_income_from_employers_and_private_pensions_")),
+          Some(messages("label.your_income_from_employers_and_private_pensions_")),
           gaAction = Some("Income"),
           gaLabel = Some("Pay As You Earn (PAYE)"),
           id = Some("paye")
@@ -247,7 +241,7 @@ class HomePageServicesProvider @Inject() (
       )
     )
 
-  private def getTaxCalculation(isTrustedHelperUser: Boolean, isRedesign: Boolean)(implicit
+  private def getTaxCalculation(isTrustedHelperUser: Boolean)(implicit
     messages: Messages
   ): Future[Option[MyService]] =
     if (isTrustedHelperUser) {
@@ -263,8 +257,7 @@ class HomePageServicesProvider @Inject() (
                 s"${current.startYear}"
               ),
               Some(configDecorator.taxCalcHomePageUrl),
-              redesignHint(
-                isRedesign,
+              Some(
                 messages("label.check_whether_you_paid_too_much_or_too_little_tax_in_a_previous_tax_year")
               ),
               gaAction = Some("Income"),
@@ -278,13 +271,13 @@ class HomePageServicesProvider @Inject() (
       }
     }
 
-  private def getNationalInsurance(isRedesign: Boolean)(implicit messages: Messages): Future[Option[MyService]] =
+  private def getNationalInsurance()(implicit messages: Messages): Future[Option[MyService]] =
     Future.successful(
       Some(
         MyService(
           messages("label.new_national_insurance_and_state_pension"),
           Some(controllers.interstitials.routes.InterstitialController.displayNISP.url),
-          nationalInsuranceHint(isRedesign),
+          Some(s"${messages("label.view_national_insurance")} ${messages("label.view_state_pension")}"),
           gaAction = Some("Income"),
           gaLabel = Some("National Insurance and State Pension"),
           id = Some("state-pension")
@@ -292,7 +285,7 @@ class HomePageServicesProvider @Inject() (
       )
     )
 
-  private def getChildBenefit(isTrustedHelperUser: Boolean, isRedesign: Boolean)(implicit
+  private def getChildBenefit(isTrustedHelperUser: Boolean)(implicit
     messages: Messages
   ): Future[Option[OtherService]] =
     Future.successful {
@@ -306,13 +299,13 @@ class HomePageServicesProvider @Inject() (
             gaAction = Some("Benefits"),
             gaLabel = Some("Child Benefit"),
             id = Some("child-benefit"),
-            hintText = redesignHint(isRedesign, messages("label.get_help_with_the_cost_of_bringing_up_children"))
+            hintText = Some(messages("label.get_help_with_the_cost_of_bringing_up_children"))
           )
         )
       }
     }
 
-  private def getAnnualTaxSummaries(isTrustedHelperUser: Boolean, isRedesign: Boolean)(implicit
+  private def getAnnualTaxSummaries(isTrustedHelperUser: Boolean)(implicit
     messages: Messages
   ): Future[Option[OtherService]] =
     Future.successful {
@@ -326,13 +319,13 @@ class HomePageServicesProvider @Inject() (
             gaAction = Some("Tax Summaries"),
             gaLabel = Some("Annual Tax Summary"),
             id = Some("tax-summary"),
-            hintText = redesignHint(isRedesign, messages("card.ats.text"))
+            hintText = Some(messages("card.ats.text"))
           )
         )
       }
     }
 
-  private def buildMarriageAllowanceServices(taxComponents: List[String], isRedesign: Boolean)(implicit
+  private def buildMarriageAllowanceServices(taxComponents: List[String])(implicit
     messages: Messages
   ): Seq[HomePageService] =
     taxComponents match {
@@ -368,13 +361,12 @@ class HomePageServicesProvider @Inject() (
             gaAction = Some("Benefits"),
             gaLabel = Some("Marriage Allowance"),
             id = Some("marriage-allowance"),
-            hintText =
-              redesignHint(isRedesign, messages("label.transfer_part_of_your_personal_allowance_to_your_partner_"))
+            hintText = Some(messages("label.transfer_part_of_your_personal_allowance_to_your_partner_"))
           )
         )
     }
 
-  private def buildTrustedHelperServices(hasRelationships: Boolean, isRedesign: Boolean)(implicit
+  private def buildTrustedHelperServices(hasRelationships: Boolean)(implicit
     messages: Messages
   ): Seq[HomePageService] =
     if (hasRelationships) {
@@ -382,7 +374,7 @@ class HomePageServicesProvider @Inject() (
         MyService(
           messages("label.trusted_helpers_heading"),
           Some(configDecorator.manageTrustedHelpersUrl),
-          redesignHint(isRedesign, messages("label.trusted_helpers_content")),
+          Some(messages("label.trusted_helpers_content")),
           gaAction = Some("Account"),
           gaLabel = Some("Trusted helpers"),
           id = Some("trusted-helper")
@@ -396,7 +388,7 @@ class HomePageServicesProvider @Inject() (
           gaAction = Some("Account"),
           gaLabel = Some("Trusted helpers"),
           id = Some("trusted-helper"),
-          hintText = redesignHint(isRedesign, messages("label.trusted_helpers_content"))
+          hintText = Some(messages("label.trusted_helpers_content"))
         )
       )
     }

--- a/app/services/HomePageServicesProvider.scala
+++ b/app/services/HomePageServicesProvider.scala
@@ -95,7 +95,7 @@ class HomePageServicesProvider @Inject() (
     MyService(
       messages("label.mtd_for_itsa"),
       Some(href),
-      Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
+      Some(messages("label.view_manage_your_mtd_it")),
       gaAction = Some("Income"),
       gaLabel = Some("MTD IT & SA"),
       id = Some("itsa")
@@ -169,7 +169,7 @@ class HomePageServicesProvider @Inject() (
             Some(
               mySaTile(
                 href = controllers.routes.SaWrongCredentialsController.landingPage().url,
-                body = messages("title.signed_in_wrong_account.h1")
+                body = messages("label.signed_in_wrong_account")
               )
             )
 

--- a/app/services/HomePageServicesProvider.scala
+++ b/app/services/HomePageServicesProvider.scala
@@ -40,7 +40,7 @@ class HomePageServicesProvider @Inject() (
 
   private val MtdItsaEnrolmentKey = "HMRC-MTD-IT"
 
-  def getHomePageServices()(implicit
+  def getHomePageServices(isRedesign: Boolean = false)(implicit
     request: UserRequest[?],
     hc: HeaderCarrier,
     messages: Messages
@@ -49,25 +49,25 @@ class HomePageServicesProvider @Inject() (
     val isTrustedHelperUser = request.trustedHelper.isDefined
     val nino                = request.authNino
 
-    val marriageAllowanceF: Future[Seq[HomePageService]] =
+    def marriageAllowanceF(isRedesign: Boolean): Future[Seq[HomePageService]] =
       if (isTrustedHelperUser) Future.successful(Seq.empty)
-      else taiService.getTaxComponentsList(nino, current.currentYear).map(buildMarriageAllowanceServices(_))
+      else taiService.getTaxComponentsList(nino, current.currentYear).map(buildMarriageAllowanceServices(_, isRedesign))
 
-    val trustedHelperF: Future[Seq[HomePageService]] =
+    def trustedHelperF(isRedesign: Boolean): Future[Seq[HomePageService]] =
       if (isTrustedHelperUser) Future.successful(Seq.empty)
-      else fandFService.isAnyFandFRelationships(nino).map(buildTrustedHelperServices(_))
+      else fandFService.isAnyFandFRelationships(nino).map(buildTrustedHelperServices(_, isRedesign))
 
     for {
       selfAssessmentMy    <- getMySelfAssessment(request.saUserType, request.enrolments, isTrustedHelperUser)
-      payAsYouEarn        <- getPayAsYouEarn()
-      taxCalc             <- getTaxCalculation(isTrustedHelperUser)
-      nationalInsurance   <- getNationalInsurance()
+      payAsYouEarn        <- getPayAsYouEarn(isRedesign)
+      taxCalc             <- getTaxCalculation(isTrustedHelperUser, isRedesign)
+      nationalInsurance   <- getNationalInsurance(isRedesign)
       selfAssessmentOther <- getOtherSelfAssessment(request.saUserType, isTrustedHelperUser)
       mtdOther            <- getMtdOtherService(isTrustedHelperUser)
-      childBenefit        <- getChildBenefit(isTrustedHelperUser)
-      annualTaxSummary    <- getAnnualTaxSummaries(isTrustedHelperUser)
-      marriageAllowance   <- marriageAllowanceF
-      trustedHelper       <- trustedHelperF
+      childBenefit        <- getChildBenefit(isTrustedHelperUser, isRedesign)
+      annualTaxSummary    <- getAnnualTaxSummaries(isTrustedHelperUser, isRedesign)
+      marriageAllowance   <- marriageAllowanceF(isRedesign)
+      trustedHelper       <- trustedHelperF(isRedesign)
     } yield HomePageServices(
       Seq(
         payAsYouEarn,
@@ -163,7 +163,7 @@ class HomePageServicesProvider @Inject() (
             Some(
               mySaTile(
                 href = controllers.routes.SaWrongCredentialsController.landingPage().url,
-                body = messages("label.signed_in_wrong_account.tile")
+                body = messages("title.signed_in_wrong_account.stop")
               )
             )
 
@@ -227,13 +227,13 @@ class HomePageServicesProvider @Inject() (
       }
     }
 
-  private def getPayAsYouEarn()(implicit messages: Messages): Future[Option[MyService]] =
+  private def getPayAsYouEarn(isRedesign: Boolean)(implicit messages: Messages): Future[Option[MyService]] =
     Future.successful(
       Some(
         MyService(
           messages("label.pay_as_you_earn_paye"),
           Some(controllers.routes.RedirectToPayeController.redirectToPaye.url),
-          Some(messages("label.your_income_from_employers_and_private_pensions_")),
+          Option.when(isRedesign)(messages("label.your_income_from_employers_and_private_pensions_")),
           gaAction = Some("Income"),
           gaLabel = Some("Pay As You Earn (PAYE)"),
           id = Some("paye")
@@ -241,7 +241,7 @@ class HomePageServicesProvider @Inject() (
       )
     )
 
-  private def getTaxCalculation(isTrustedHelperUser: Boolean)(implicit
+  private def getTaxCalculation(isTrustedHelperUser: Boolean, isRedesign: Boolean)(implicit
     messages: Messages
   ): Future[Option[MyService]] =
     if (isTrustedHelperUser) {
@@ -257,7 +257,7 @@ class HomePageServicesProvider @Inject() (
                 s"${current.startYear}"
               ),
               Some(configDecorator.taxCalcHomePageUrl),
-              Some(
+              Option.when(isRedesign)(
                 messages("label.check_whether_you_paid_too_much_or_too_little_tax_in_a_previous_tax_year")
               ),
               gaAction = Some("Income"),
@@ -271,13 +271,15 @@ class HomePageServicesProvider @Inject() (
       }
     }
 
-  private def getNationalInsurance()(implicit messages: Messages): Future[Option[MyService]] =
+  private def getNationalInsurance(isRedesign: Boolean)(implicit messages: Messages): Future[Option[MyService]] =
     Future.successful(
       Some(
         MyService(
           messages("label.new_national_insurance_and_state_pension"),
           Some(controllers.interstitials.routes.InterstitialController.displayNISP.url),
-          Some(s"${messages("label.view_national_insurance")} ${messages("label.view_state_pension")}"),
+          Option.when(isRedesign)(
+            s"${messages("label.view_national_insurance")} ${messages("label.view_state_pension")}"
+          ),
           gaAction = Some("Income"),
           gaLabel = Some("National Insurance and State Pension"),
           id = Some("state-pension")
@@ -285,7 +287,7 @@ class HomePageServicesProvider @Inject() (
       )
     )
 
-  private def getChildBenefit(isTrustedHelperUser: Boolean)(implicit
+  private def getChildBenefit(isTrustedHelperUser: Boolean, isRedesign: Boolean)(implicit
     messages: Messages
   ): Future[Option[OtherService]] =
     Future.successful {
@@ -299,13 +301,13 @@ class HomePageServicesProvider @Inject() (
             gaAction = Some("Benefits"),
             gaLabel = Some("Child Benefit"),
             id = Some("child-benefit"),
-            hintText = Some(messages("label.get_help_with_the_cost_of_bringing_up_children"))
+            hintText = Option.when(isRedesign)(messages("label.get_help_with_the_cost_of_bringing_up_children"))
           )
         )
       }
     }
 
-  private def getAnnualTaxSummaries(isTrustedHelperUser: Boolean)(implicit
+  private def getAnnualTaxSummaries(isTrustedHelperUser: Boolean, isRedesign: Boolean)(implicit
     messages: Messages
   ): Future[Option[OtherService]] =
     Future.successful {
@@ -319,13 +321,13 @@ class HomePageServicesProvider @Inject() (
             gaAction = Some("Tax Summaries"),
             gaLabel = Some("Annual Tax Summary"),
             id = Some("tax-summary"),
-            hintText = Some(messages("card.ats.text"))
+            hintText = Option.when(isRedesign)(messages("card.ats.text"))
           )
         )
       }
     }
 
-  private def buildMarriageAllowanceServices(taxComponents: List[String])(implicit
+  private def buildMarriageAllowanceServices(taxComponents: List[String], isRedesign: Boolean)(implicit
     messages: Messages
   ): Seq[HomePageService] =
     taxComponents match {
@@ -361,12 +363,13 @@ class HomePageServicesProvider @Inject() (
             gaAction = Some("Benefits"),
             gaLabel = Some("Marriage Allowance"),
             id = Some("marriage-allowance"),
-            hintText = Some(messages("label.transfer_part_of_your_personal_allowance_to_your_partner_"))
+            hintText =
+              Option.when(isRedesign)(messages("label.transfer_part_of_your_personal_allowance_to_your_partner_"))
           )
         )
     }
 
-  private def buildTrustedHelperServices(hasRelationships: Boolean)(implicit
+  private def buildTrustedHelperServices(hasRelationships: Boolean, isRedesign: Boolean)(implicit
     messages: Messages
   ): Seq[HomePageService] =
     if (hasRelationships) {
@@ -374,7 +377,7 @@ class HomePageServicesProvider @Inject() (
         MyService(
           messages("label.trusted_helpers_heading"),
           Some(configDecorator.manageTrustedHelpersUrl),
-          Some(messages("label.trusted_helpers_content")),
+          Option.when(isRedesign)(messages("label.trusted_helpers_content")),
           gaAction = Some("Account"),
           gaLabel = Some("Trusted helpers"),
           id = Some("trusted-helper")
@@ -388,7 +391,7 @@ class HomePageServicesProvider @Inject() (
           gaAction = Some("Account"),
           gaLabel = Some("Trusted helpers"),
           id = Some("trusted-helper"),
-          hintText = Some(messages("label.trusted_helpers_content"))
+          hintText = Option.when(isRedesign)(messages("label.trusted_helpers_content"))
         )
       )
     }

--- a/app/services/HomePageServicesProvider.scala
+++ b/app/services/HomePageServicesProvider.scala
@@ -95,7 +95,7 @@ class HomePageServicesProvider @Inject() (
     MyService(
       messages("label.mtd_for_itsa"),
       Some(href),
-      Some(messages("label.view_manage_your_mtd_it")),
+      Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
       gaAction = Some("Income"),
       gaLabel = Some("MTD IT & SA"),
       id = Some("itsa")
@@ -169,7 +169,7 @@ class HomePageServicesProvider @Inject() (
             Some(
               mySaTile(
                 href = controllers.routes.SaWrongCredentialsController.landingPage().url,
-                body = messages("label.signed_in_wrong_account")
+                body = messages("label.signed_in_wrong_account.tile")
               )
             )
 

--- a/conf/messages
+++ b/conf/messages
@@ -441,7 +441,7 @@ label.you_have_no_payments_to_make_to_hmrc=You have no payments to make to HMRC.
 
 label.self_assessment=Self Assessment
 label.mtd_for_itsa=Self Assessment and Making Tax Digital for Income Tax
-label.view_and_manage_your_income_tax_obligations_and_payments=View and manage your Income Tax obligations and payments.
+label.view_and_manage_your_income_tax_obligations_and_payments=View and manage your Income Tax obligations and payments
 label.make_a_payment=Make a payment
 label.check_if_you_need_to_fill_in_a_tax_return=Check if you need to fill in a tax return
 label.find_out_how_to_access_self_assessment=Find out how to access Self Assessment

--- a/conf/messages
+++ b/conf/messages
@@ -499,7 +499,6 @@ label.send_updates_hmrc_compatible_software=Send updates using HMRC compatible s
 label.send_updates_sole_traders=For sole traders and landlords that send quarterly updates using software.
 label.view_manage_your_mtd_for_it=View and manage Making Tax Digital for Income Tax
 label.view_manage_your_mtd_itsa=View and manage your Making Tax Digital for Income Tax or access your Self Assessment tax returns.
-label.view_manage_your_mtd_it=View and manage Making Tax Digital for Income Tax, and access Self Assessment.
 label.itsa_header=Income Tax Self Assessment
 label.it_header=Income Tax
 label.view_manage_sa_return=More details about your Self Assessment returns and payments
@@ -507,7 +506,6 @@ label.access_your_sa_returns=Access your Self Assessment tax returns
 label.old_way_sa_returns=The old way for filing your Self Assessment tax returns.
 label.self_assessment_tax_returns=Self Assessment tax returns
 label.online_deadline_final_declarations=The deadline for final declarations or online returns is 31 January {0}.
-label.online_deadline_tax_returns=The deadline for tax returns is 31 January {0}.
 label.making_tax_digital=Making Tax Digital
 
 label.mtdit.heading=Making Tax Digital for Income Tax

--- a/conf/messages
+++ b/conf/messages
@@ -440,7 +440,7 @@ label.you_owe_hmrc_you_must_pay_by_=You owe HMRC £{0}. You must pay by {1}.
 label.you_have_no_payments_to_make_to_hmrc=You have no payments to make to HMRC.
 
 label.self_assessment=Self Assessment
-label.mtd_for_itsa=Making Tax Digital for Income Tax and Self Assessment
+label.mtd_for_itsa=Self Assessment and Making Tax Digital for Income Tax
 label.view_and_manage_your_income_tax_obligations_and_payments=View and manage your Income Tax obligations and payments.
 label.make_a_payment=Make a payment
 label.check_if_you_need_to_fill_in_a_tax_return=Check if you need to fill in a tax return

--- a/conf/messages
+++ b/conf/messages
@@ -643,6 +643,7 @@ label.access_your_self_assessment=Access your Self Assessment
 
 title.signed_in_wrong_account.h1=You are not signed in to the right account
 label.signed_in_wrong_account=You used a different account when you first signed-up to view or send your tax returns online.
+label.signed_in_wrong_account.tile=You are not signed in to the right account.
 
 title.sign_in_again.h1=You need to sign back in to Government Gateway using different details
 label.sign_in_again=You will be asked to sign in again with the user ID and password for the account you use for Self Assessment.

--- a/conf/messages
+++ b/conf/messages
@@ -499,6 +499,7 @@ label.send_updates_hmrc_compatible_software=Send updates using HMRC compatible s
 label.send_updates_sole_traders=For sole traders and landlords that send quarterly updates using software.
 label.view_manage_your_mtd_for_it=View and manage Making Tax Digital for Income Tax
 label.view_manage_your_mtd_itsa=View and manage your Making Tax Digital for Income Tax or access your Self Assessment tax returns.
+label.view_manage_your_mtd_it=View and manage Making Tax Digital for Income Tax and access Self Assessment.
 label.itsa_header=Income Tax Self Assessment
 label.it_header=Income Tax
 label.view_manage_sa_return=More details about your Self Assessment returns and payments

--- a/conf/messages
+++ b/conf/messages
@@ -644,7 +644,6 @@ label.access_your_self_assessment=Access your Self Assessment
 title.signed_in_wrong_account.h1=You are not signed in to the right account
 title.signed_in_wrong_account.stop=You are not signed in to the right account.
 label.signed_in_wrong_account=You used a different account when you first signed-up to view or send your tax returns online.
-label.signed_in_wrong_account.tile=You are not signed in to the right account.
 
 title.sign_in_again.h1=You need to sign back in to Government Gateway using different details
 label.sign_in_again=You will be asked to sign in again with the user ID and password for the account you use for Self Assessment.

--- a/conf/messages
+++ b/conf/messages
@@ -441,7 +441,7 @@ label.you_have_no_payments_to_make_to_hmrc=You have no payments to make to HMRC.
 
 label.self_assessment=Self Assessment
 label.mtd_for_itsa=Self Assessment and Making Tax Digital for Income Tax
-label.view_and_manage_your_income_tax_obligations_and_payments=View and manage your Income Tax obligations and payments
+label.view_and_manage_your_income_tax_obligations_and_payments=View and manage your Income Tax obligations and payments.
 label.make_a_payment=Make a payment
 label.check_if_you_need_to_fill_in_a_tax_return=Check if you need to fill in a tax return
 label.find_out_how_to_access_self_assessment=Find out how to access Self Assessment

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -639,6 +639,7 @@ label.access_your_self_assessment=Cael at eich cyfrif Hunanasesiad
 
 title.signed_in_wrong_account.h1=Nid ydych wedi mewngofnodi i’r cyfrif cywir
 label.signed_in_wrong_account=Defnyddioch gyfrif gwahanol pan wnaethoch gofrestru gyntaf i fwrw golwg dros eich Ffurflenni Treth, neu eu hanfon, ar-lein.
+label.signed_in_wrong_account.tile=Nid ydych wedi mewngofnodi i’r cyfrif cywir.
 
 title.sign_in_again.h1=Mae angen i chi fewngofnodi eto i Borth y Llywodraeth gan ddefnyddio manylion gwahanol
 label.sign_in_again=Gofynnir i chi fewngofnodi eto gyda’r Dynodydd Defnyddiwr (ID) a’r cyfrinair ar gyfer y cyfrif rydych yn ei ddefnyddio ar gyfer Hunanasesiad.
@@ -820,7 +821,7 @@ tax_credits.ended.information.how.continue.li2 = cysylltu â Gwasanaeth Cwsmeria
 
 label.mtd_for_it=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.mtd_for_itsa=Hunanasesiad a Throi Treth yn Ddigidol ar gyfer Treth Incwm
-label.view_and_manage_your_income_tax_obligations_and_payments=Bwrw golwg dros a rheoli’ch rhwymedigaethau a’ch taliadau Treth Incwm.
+label.view_and_manage_your_income_tax_obligations_and_payments=Bwrw golwg dros eich rhwymedigaethau a’ch taliadau Treth Incwm, a’u rheoli.
 label.mtd_for_it_sa=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.send_updates_sole_traders=Ar gyfer unig fasnachwyr a landlordiaid sy’n anfon diweddariadau chwarterol gan ddefnyddio meddalwedd.
 label.view_manage_your_mtd_for_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -825,6 +825,7 @@ label.mtd_for_it_sa=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.send_updates_sole_traders=Ar gyfer unig fasnachwyr a landlordiaid sy’n anfon diweddariadau chwarterol gan ddefnyddio meddalwedd.
 label.view_manage_your_mtd_for_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli
 label.view_manage_your_mtd_itsa=Bwrw golwg dros eich cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli, neu gael at eich Ffurflenni Treth Hunanasesiad.
+label.view_manage_your_mtd_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli, a chael mynediad at Hunanasesiad.
 label.it_header=Treth Incwm
 
 waiting_for_callback=Os ydych yn aros i gael galwad ffôn yn ôl

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -825,9 +825,7 @@ label.mtd_for_it_sa=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.send_updates_sole_traders=Ar gyfer unig fasnachwyr a landlordiaid sy’n anfon diweddariadau chwarterol gan ddefnyddio meddalwedd.
 label.view_manage_your_mtd_for_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli
 label.view_manage_your_mtd_itsa=Bwrw golwg dros eich cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli, neu gael at eich Ffurflenni Treth Hunanasesiad.
-label.view_manage_your_mtd_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli, a chael mynediad at Hunanasesiad.
 label.it_header=Treth Incwm
-label.online_deadline_tax_returns=Y dyddiad cau ar gyfer cyflwyno Ffurflenni Treth yw 31 Ionawr {0}.
 
 waiting_for_callback=Os ydych yn aros i gael galwad ffôn yn ôl
 no_need_to_contact=, does dim angen i chi gysylltu â ni eto.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -820,7 +820,7 @@ tax_credits.ended.information.how.continue.li2 = cysylltu â Gwasanaeth Cwsmeria
 
 label.mtd_for_it=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.mtd_for_itsa=Hunanasesiad a Throi Treth yn Ddigidol ar gyfer Treth Incwm
-label.view_and_manage_your_income_tax_obligations_and_payments=Bwrw golwg dros a rheoli’ch rhwymedigaethau a’ch taliadau Treth Incwm
+label.view_and_manage_your_income_tax_obligations_and_payments=Bwrw golwg dros a rheoli’ch rhwymedigaethau a’ch taliadau Treth Incwm.
 label.mtd_for_it_sa=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.send_updates_sole_traders=Ar gyfer unig fasnachwyr a landlordiaid sy’n anfon diweddariadau chwarterol gan ddefnyddio meddalwedd.
 label.view_manage_your_mtd_for_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -819,7 +819,7 @@ tax_credits.ended.information.how.continue.li2 = cysylltu â Gwasanaeth Cwsmeria
 
 
 label.mtd_for_it=Troi Treth yn Ddigidol ar gyfer Treth Incwm
-label.mtd_for_itsa=Troi Treth yn Ddigidol ar gyfer Treth Incwm a Hunanasesiad
+label.mtd_for_itsa=Hunanasesiad a Throi Treth yn Ddigidol ar gyfer Treth Incwm
 label.view_and_manage_your_income_tax_obligations_and_payments=Bwrw golwg dros a rheoli’ch rhwymedigaethau a’ch taliadau Treth Incwm.
 label.mtd_for_it_sa=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.send_updates_sole_traders=Ar gyfer unig fasnachwyr a landlordiaid sy’n anfon diweddariadau chwarterol gan ddefnyddio meddalwedd.

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -820,7 +820,7 @@ tax_credits.ended.information.how.continue.li2 = cysylltu â Gwasanaeth Cwsmeria
 
 label.mtd_for_it=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.mtd_for_itsa=Hunanasesiad a Throi Treth yn Ddigidol ar gyfer Treth Incwm
-label.view_and_manage_your_income_tax_obligations_and_payments=Bwrw golwg dros a rheoli’ch rhwymedigaethau a’ch taliadau Treth Incwm.
+label.view_and_manage_your_income_tax_obligations_and_payments=Bwrw golwg dros a rheoli’ch rhwymedigaethau a’ch taliadau Treth Incwm
 label.mtd_for_it_sa=Troi Treth yn Ddigidol ar gyfer Treth Incwm
 label.send_updates_sole_traders=Ar gyfer unig fasnachwyr a landlordiaid sy’n anfon diweddariadau chwarterol gan ddefnyddio meddalwedd.
 label.view_manage_your_mtd_for_it=Bwrw golwg dros y cynllun Troi Treth yn Ddigidol ar gyfer Treth Incwm a’i reoli

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -640,7 +640,6 @@ label.access_your_self_assessment=Cael at eich cyfrif Hunanasesiad
 title.signed_in_wrong_account.h1=Nid ydych wedi mewngofnodi i’r cyfrif cywir
 title.signed_in_wrong_account.stop=Nid ydych wedi mewngofnodi i’r cyfrif cywir.
 label.signed_in_wrong_account=Defnyddioch gyfrif gwahanol pan wnaethoch gofrestru gyntaf i fwrw golwg dros eich Ffurflenni Treth, neu eu hanfon, ar-lein.
-label.signed_in_wrong_account.tile=Nid ydych wedi mewngofnodi i’r cyfrif cywir.
 
 title.sign_in_again.h1=Mae angen i chi fewngofnodi eto i Borth y Llywodraeth gan ddefnyddio manylion gwahanol
 label.sign_in_again=Gofynnir i chi fewngofnodi eto gyda’r Dynodydd Defnyddiwr (ID) a’r cyfrinair ar gyfer y cyfrif rydych yn ei ddefnyddio ar gyfer Hunanasesiad.

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -144,7 +144,7 @@ class HomeControllerSpec extends BaseSpec with WireMockHelper with CitizenDetail
     when(mockConfigDecorator.ptapHomepageNinoRolloutLastNumericDigits)
       .thenReturn(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
 
-    when(mockHomePageServicesProvider.getHomePageServices()(any(), any(), any()))
+    when(mockHomePageServicesProvider.getHomePageServices(any())(any(), any(), any()))
       .thenReturn(Future.successful(HomePageServices(Seq.empty)))
 
     when(mockCitizenDetailsService.personDetails(any(), any())(any(), any(), any()))
@@ -667,7 +667,7 @@ class HomeControllerSpec extends BaseSpec with WireMockHelper with CitizenDetail
         hintText = Some("Child Benefit hint")
       )
 
-      when(mockHomePageServicesProvider.getHomePageServices()(any(), any(), any()))
+      when(mockHomePageServicesProvider.getHomePageServices(any())(any(), any(), any()))
         .thenReturn(Future.successful(HomePageServices(Seq(payeService, childBenefitService))))
 
       val appLocal   = appBuilder.build()

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -25,7 +25,7 @@ import models.BreathingSpaceIndicatorResponse.WithinPeriod
 import models.admin.{GetPersonFromCitizenDetailsToggle, HomePagePersonalisationToggle, PtapActivityTabToggle, ShowPlannedOutageBannerToggle}
 import models.{BreathingSpaceIndicatorResponse, HomePageServices, MyService, OtherService}
 import org.jsoup.Jsoup
-import org.mockito.ArgumentMatchers.{any, anyBoolean}
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
 import play.api.Application
 import play.api.i18n.{Lang, Messages, MessagesImpl}
@@ -144,7 +144,7 @@ class HomeControllerSpec extends BaseSpec with WireMockHelper with CitizenDetail
     when(mockConfigDecorator.ptapHomepageNinoRolloutLastNumericDigits)
       .thenReturn(Seq(0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
 
-    when(mockHomePageServicesProvider.getHomePageServices(anyBoolean())(any(), any(), any()))
+    when(mockHomePageServicesProvider.getHomePageServices()(any(), any(), any()))
       .thenReturn(Future.successful(HomePageServices(Seq.empty)))
 
     when(mockCitizenDetailsService.personDetails(any(), any())(any(), any(), any()))
@@ -667,7 +667,7 @@ class HomeControllerSpec extends BaseSpec with WireMockHelper with CitizenDetail
         hintText = Some("Child Benefit hint")
       )
 
-      when(mockHomePageServicesProvider.getHomePageServices(anyBoolean())(any(), any(), any()))
+      when(mockHomePageServicesProvider.getHomePageServices()(any(), any(), any()))
         .thenReturn(Future.successful(HomePageServices(Seq(payeService, childBenefitService))))
 
       val appLocal   = appBuilder.build()

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -216,7 +216,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           "Self Assessment",
           Some(controllers.routes.SaWrongCredentialsController.landingPage().url),
-          Some(messages("label.signed_in_wrong_account.tile")),
+          Some(messages("title.signed_in_wrong_account.stop")),
           Map(),
           Some("Income"),
           Some("Self Assessment"),
@@ -636,7 +636,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
       when(mockFeatureFlagService.get(eqTo(ShowTaxCalcTileToggle)))
         .thenReturn(Future.successful(FeatureFlag(ShowTaxCalcTileToggle, isEnabled = true)))
 
-      val result = service.getHomePageServices().futureValue
+      val result = service.getHomePageServices(isRedesign = true).futureValue
 
       result.myServices.find(_.title == "Pay As You Earn (PAYE)").flatMap(_.hintText) mustBe
         Some(messages("label.your_income_from_employers_and_private_pensions_"))

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -216,7 +216,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           "Self Assessment",
           Some(controllers.routes.SaWrongCredentialsController.landingPage().url),
-          Some(messages("title.signed_in_wrong_account.h1")),
+          Some(messages("label.signed_in_wrong_account")),
           Map(),
           Some("Income"),
           Some("Self Assessment"),
@@ -247,7 +247,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage your Income Tax obligations and payments."),
+          Some("View and manage Making Tax Digital for Income Tax and access Self Assessment."),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -271,7 +271,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage your Income Tax obligations and payments."),
+          Some("View and manage Making Tax Digital for Income Tax and access Self Assessment."),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -295,7 +295,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage your Income Tax obligations and payments."),
+          Some("View and manage Making Tax Digital for Income Tax and access Self Assessment."),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -319,7 +319,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage your Income Tax obligations and payments."),
+          Some("View and manage Making Tax Digital for Income Tax and access Self Assessment."),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -342,8 +342,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
 
       val itsaService = result.myServices.find(_.id.contains("itsa"))
       itsaService.map(_.title) mustBe Some(welshMessages("label.mtd_for_itsa"))
-      itsaService.flatMap(_.hintText) mustBe
-        Some(welshMessages("label.view_and_manage_your_income_tax_obligations_and_payments"))
+      itsaService.flatMap(_.hintText) mustBe Some(welshMessages("label.view_manage_your_mtd_it"))
       result.myServices.map(_.title)    must contain(welshMessages("label.mtd_for_itsa"))
       result.otherServices.map(_.title) must not contain welshMessages("label.mtd_for_itsa")
       result.otherServices.map(_.title) must not contain welshMessages("label.self_assessment")

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -26,7 +26,7 @@ import play.api.i18n.{Lang, Messages, MessagesImpl}
 import play.api.mvc.AnyContent
 import play.api.test.FakeRequest
 import testUtils.BaseSpec
-import uk.gov.hmrc.auth.core.ConfidenceLevel
+import uk.gov.hmrc.auth.core.{ConfidenceLevel, Enrolment}
 import uk.gov.hmrc.auth.core.retrieve.Credentials
 import uk.gov.hmrc.domain.SaUtr
 import uk.gov.hmrc.mongoFeatureToggles.model.FeatureFlag
@@ -55,7 +55,8 @@ class HomePageServicesProviderSpec extends BaseSpec {
 
   private def buildRequest(
     saUserType: SelfAssessmentUserType = NonFilerSelfAssessmentUser,
-    trustedHelper: Option[TrustedHelper] = None
+    trustedHelper: Option[TrustedHelper] = None,
+    hasMtdItsaEnrolment: Boolean = false
   ): UserRequest[AnyContent] =
     UserRequest(
       authNino = generatedNino,
@@ -63,7 +64,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
       credentials = Credentials("credId", "GovernmentGateway"),
       confidenceLevel = ConfidenceLevel.L200,
       trustedHelper = trustedHelper,
-      enrolments = Set.empty,
+      enrolments = if (hasMtdItsaEnrolment) Set(Enrolment("HMRC-MTD-IT")) else Set.empty,
       profile = None,
       breadcrumb = None,
       request = FakeRequest(),
@@ -228,6 +229,124 @@ class HomePageServicesProviderSpec extends BaseSpec {
           id = Some("mtdit")
         )
       )
+    }
+
+    "return combined MTD/SA tile in myServices for activated online filer with HMRC-MTD-IT when redesign is true" in {
+      implicit val request: UserRequest[AnyContent] =
+        buildRequest(ActivatedOnlineFilerSelfAssessmentUser(SaUtr("11")), hasMtdItsaEnrolment = true)
+
+      val result = service.getHomePageServices(isRedesign = true).futureValue
+
+      result.myServices                 must contain(
+        MyService(
+          messages("label.mtd_for_itsa"),
+          Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
+          Some(
+            s"${messages("label.view_manage_your_mtd_it")} ${messages("label.online_deadline_tax_returns", (TaxYear.current.startYear + 1).toString)}"
+          ),
+          Map(),
+          Some("Income"),
+          Some("MTD IT & SA"),
+          id = Some("itsa")
+        )
+      )
+      result.myServices.map(_.title)    must contain(messages("label.mtd_for_itsa"))
+      result.otherServices.map(_.title) must not contain messages("label.mtd_for_itsa")
+      result.otherServices.map(_.title) must not contain messages("label.self_assessment")
+      result.otherServices.map(_.link)  must not contain
+        controllers.interstitials.routes.MtdAdvertInterstitialController.displayMTDITPage.url
+    }
+
+    "return combined MTD/SA tile in myServices without hint for activated online filer with HMRC-MTD-IT when redesign is false" in {
+      implicit val request: UserRequest[AnyContent] =
+        buildRequest(ActivatedOnlineFilerSelfAssessmentUser(SaUtr("11")), hasMtdItsaEnrolment = true)
+
+      val result = service.getHomePageServices().futureValue
+
+      result.myServices                 must contain(
+        MyService(
+          messages("label.mtd_for_itsa"),
+          Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
+          None,
+          Map(),
+          Some("Income"),
+          Some("MTD IT & SA"),
+          id = Some("itsa")
+        )
+      )
+      result.myServices.map(_.title)    must contain(messages("label.mtd_for_itsa"))
+      result.otherServices.map(_.title) must not contain messages("label.mtd_for_itsa")
+      result.otherServices.map(_.title) must not contain messages("label.self_assessment")
+      result.otherServices.map(_.link)  must not contain
+        controllers.interstitials.routes.MtdAdvertInterstitialController.displayMTDITPage.url
+    }
+
+    "return combined MTD/SA tile in myServices for wrong credentials user with HMRC-MTD-IT when redesign is true" in {
+      implicit val request: UserRequest[AnyContent] =
+        buildRequest(WrongCredentialsSelfAssessmentUser(SaUtr("11")), hasMtdItsaEnrolment = true)
+
+      val result = service.getHomePageServices(isRedesign = true).futureValue
+
+      result.myServices                 must contain(
+        MyService(
+          messages("label.mtd_for_itsa"),
+          Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
+          Some(
+            s"${messages("label.view_manage_your_mtd_it")} ${messages("label.online_deadline_tax_returns", (TaxYear.current.startYear + 1).toString)}"
+          ),
+          Map(),
+          Some("Income"),
+          Some("MTD IT & SA"),
+          id = Some("itsa")
+        )
+      )
+      result.myServices.map(_.title)    must contain(messages("label.mtd_for_itsa"))
+      result.otherServices.map(_.title) must not contain messages("label.mtd_for_itsa")
+      result.otherServices.map(_.title) must not contain messages("label.self_assessment")
+      result.otherServices.map(_.link)  must not contain
+        controllers.interstitials.routes.MtdAdvertInterstitialController.displayMTDITPage.url
+    }
+
+    "return combined MTD/SA tile in myServices without hint for wrong credentials user with HMRC-MTD-IT when redesign is false" in {
+      implicit val request: UserRequest[AnyContent] =
+        buildRequest(WrongCredentialsSelfAssessmentUser(SaUtr("11")), hasMtdItsaEnrolment = true)
+
+      val result = service.getHomePageServices().futureValue
+
+      result.myServices                 must contain(
+        MyService(
+          messages("label.mtd_for_itsa"),
+          Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
+          None,
+          Map(),
+          Some("Income"),
+          Some("MTD IT & SA"),
+          id = Some("itsa")
+        )
+      )
+      result.myServices.map(_.title)    must contain(messages("label.mtd_for_itsa"))
+      result.otherServices.map(_.title) must not contain messages("label.mtd_for_itsa")
+      result.otherServices.map(_.title) must not contain messages("label.self_assessment")
+      result.otherServices.map(_.link)  must not contain
+        controllers.interstitials.routes.MtdAdvertInterstitialController.displayMTDITPage.url
+    }
+
+    "return Welsh content for combined MTD/SA tile in myServices for activated online filer with HMRC-MTD-IT" in {
+      implicit val welshMessages: Messages          = MessagesImpl(Lang("cy"), messagesApi)
+      implicit val request: UserRequest[AnyContent] =
+        buildRequest(ActivatedOnlineFilerSelfAssessmentUser(SaUtr("11")), hasMtdItsaEnrolment = true)
+
+      val result = service.getHomePageServices(isRedesign = true).futureValue
+
+      val itsaService = result.myServices.find(_.id.contains("itsa"))
+      itsaService.map(_.title) mustBe Some(welshMessages("label.mtd_for_itsa"))
+      itsaService.flatMap(_.hintText) mustBe
+        Some(
+          s"${welshMessages("label.view_manage_your_mtd_it")} ${welshMessages("label.online_deadline_tax_returns", (TaxYear.current.startYear + 1).toString)}"
+        )
+      result.myServices.map(_.title)    must contain(welshMessages("label.mtd_for_itsa"))
+      result.otherServices.map(_.title) must not contain welshMessages("label.mtd_for_itsa")
+      result.otherServices.map(_.title) must not contain welshMessages("label.self_assessment")
     }
 
     "return self assessment and MTD in otherServices for not yet activated SA user" in {

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -216,7 +216,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           "Self Assessment",
           Some(controllers.routes.SaWrongCredentialsController.landingPage().url),
-          Some(messages("label.signed_in_wrong_account")),
+          Some(messages("label.signed_in_wrong_account.tile")),
           Map(),
           Some("Income"),
           Some("Self Assessment"),
@@ -247,7 +247,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage Making Tax Digital for Income Tax and access Self Assessment."),
+          Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -271,7 +271,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage Making Tax Digital for Income Tax and access Self Assessment."),
+          Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -295,7 +295,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage Making Tax Digital for Income Tax and access Self Assessment."),
+          Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -319,7 +319,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage Making Tax Digital for Income Tax and access Self Assessment."),
+          Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -342,7 +342,9 @@ class HomePageServicesProviderSpec extends BaseSpec {
 
       val itsaService = result.myServices.find(_.id.contains("itsa"))
       itsaService.map(_.title) mustBe Some(welshMessages("label.mtd_for_itsa"))
-      itsaService.flatMap(_.hintText) mustBe Some(welshMessages("label.view_manage_your_mtd_it"))
+      itsaService.flatMap(_.hintText) mustBe Some(
+        welshMessages("label.view_and_manage_your_income_tax_obligations_and_payments")
+      )
       result.myServices.map(_.title)    must contain(welshMessages("label.mtd_for_itsa"))
       result.otherServices.map(_.title) must not contain welshMessages("label.mtd_for_itsa")
       result.otherServices.map(_.title) must not contain welshMessages("label.self_assessment")

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -241,7 +241,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage your Income Tax obligations and payments"),
+          Some("View and manage your Income Tax obligations and payments."),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -289,7 +289,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some("View and manage your Income Tax obligations and payments"),
+          Some("View and manage your Income Tax obligations and payments."),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -241,9 +241,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some(
-            s"${messages("label.view_manage_your_mtd_it")} ${messages("label.online_deadline_tax_returns", (TaxYear.current.startYear + 1).toString)}"
-          ),
+          Some("View and manage your Income Tax obligations and payments"),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -291,9 +289,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
         MyService(
           messages("label.mtd_for_itsa"),
           Some(controllers.interstitials.routes.InterstitialController.displayItsaMergePage.url),
-          Some(
-            s"${messages("label.view_manage_your_mtd_it")} ${messages("label.online_deadline_tax_returns", (TaxYear.current.startYear + 1).toString)}"
-          ),
+          Some("View and manage your Income Tax obligations and payments"),
           Map(),
           Some("Income"),
           Some("MTD IT & SA"),
@@ -341,9 +337,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
       val itsaService = result.myServices.find(_.id.contains("itsa"))
       itsaService.map(_.title) mustBe Some(welshMessages("label.mtd_for_itsa"))
       itsaService.flatMap(_.hintText) mustBe
-        Some(
-          s"${welshMessages("label.view_manage_your_mtd_it")} ${welshMessages("label.online_deadline_tax_returns", (TaxYear.current.startYear + 1).toString)}"
-        )
+        Some(welshMessages("label.view_and_manage_your_income_tax_obligations_and_payments"))
       result.myServices.map(_.title)    must contain(welshMessages("label.mtd_for_itsa"))
       result.otherServices.map(_.title) must not contain welshMessages("label.mtd_for_itsa")
       result.otherServices.map(_.title) must not contain welshMessages("label.self_assessment")

--- a/test/services/HomePageServicesProviderSpec.scala
+++ b/test/services/HomePageServicesProviderSpec.scala
@@ -241,7 +241,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
       implicit val request: UserRequest[AnyContent] =
         buildRequest(ActivatedOnlineFilerSelfAssessmentUser(SaUtr("11")), hasMtdItsaEnrolment = true)
 
-      val result = service.getHomePageServices(isRedesign = true).futureValue
+      val result = service.getHomePageServices().futureValue
 
       result.myServices                 must contain(
         MyService(
@@ -289,7 +289,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
       implicit val request: UserRequest[AnyContent] =
         buildRequest(WrongCredentialsSelfAssessmentUser(SaUtr("11")), hasMtdItsaEnrolment = true)
 
-      val result = service.getHomePageServices(isRedesign = true).futureValue
+      val result = service.getHomePageServices().futureValue
 
       result.myServices                 must contain(
         MyService(
@@ -338,7 +338,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
       implicit val request: UserRequest[AnyContent] =
         buildRequest(ActivatedOnlineFilerSelfAssessmentUser(SaUtr("11")), hasMtdItsaEnrolment = true)
 
-      val result = service.getHomePageServices(isRedesign = true).futureValue
+      val result = service.getHomePageServices().futureValue
 
       val itsaService = result.myServices.find(_.id.contains("itsa"))
       itsaService.map(_.title) mustBe Some(welshMessages("label.mtd_for_itsa"))
@@ -636,7 +636,7 @@ class HomePageServicesProviderSpec extends BaseSpec {
       when(mockFeatureFlagService.get(eqTo(ShowTaxCalcTileToggle)))
         .thenReturn(Future.successful(FeatureFlag(ShowTaxCalcTileToggle, isEnabled = true)))
 
-      val result = service.getHomePageServices(isRedesign = true).futureValue
+      val result = service.getHomePageServices().futureValue
 
       result.myServices.find(_.title == "Pay As You Earn (PAYE)").flatMap(_.hintText) mustBe
         Some(messages("label.your_income_from_employers_and_private_pensions_"))

--- a/test/views/html/HomeViewSpec.scala
+++ b/test/views/html/HomeViewSpec.scala
@@ -143,16 +143,14 @@ class HomeViewSpec extends ViewSpec {
       val combinedService                                           = MyService(
         messages("label.mtd_for_itsa"),
         Some("/itsa"),
-        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
+        Some(messages("label.view_manage_your_mtd_it")),
         id = Some("itsa")
       )
 
       val document = asDocument(home(homeViewModel.copy(myServices = Seq(combinedService))).toString)
 
       document.select("ul#my_taxes li#itsa a").text() mustBe messages("label.mtd_for_itsa")
-      document.select("ul#my_taxes li#itsa p.govuk-body").text() mustBe messages(
-        "label.view_and_manage_your_income_tax_obligations_and_payments"
-      )
+      document.select("ul#my_taxes li#itsa p.govuk-body").text() mustBe messages("label.view_manage_your_mtd_it")
     }
 
     "show the alert banner if there is some alert content" in {

--- a/test/views/html/HomeViewSpec.scala
+++ b/test/views/html/HomeViewSpec.scala
@@ -19,7 +19,7 @@ package views.html
 import config.ConfigDecorator
 import controllers.auth.requests.UserRequest
 import controllers.bindable.Origin
-import models.MyService
+import models.{MyService, OtherService}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.ArgumentMatchers.any
@@ -151,6 +151,23 @@ class HomeViewSpec extends ViewSpec {
 
       document.select("ul#my_taxes li#itsa a").text() mustBe messages("label.mtd_for_itsa")
       document.select("ul#my_taxes li#itsa p.govuk-body").text() mustBe messages("label.view_manage_your_mtd_it")
+    }
+
+    "render Self Assessment other service supporting text in the current design" in {
+      implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
+      val selfAssessmentService                                     = OtherService(
+        messages("label.self_assessment"),
+        "/self-assessment",
+        id = Some("self-assessment"),
+        hintText = Some(messages("label.activate_your_self_assessment"))
+      )
+
+      val document = asDocument(home(homeViewModel.copy(otherServices = Seq(selfAssessmentService))).toString)
+
+      document.select("ul#other_taxes li#self-assessment a").text() mustBe messages("label.self_assessment")
+      document.select("ul#other_taxes li#self-assessment p.govuk-body").text() mustBe messages(
+        "label.activate_your_self_assessment"
+      )
     }
 
     "show the alert banner if there is some alert content" in {

--- a/test/views/html/HomeViewSpec.scala
+++ b/test/views/html/HomeViewSpec.scala
@@ -19,6 +19,7 @@ package views.html
 import config.ConfigDecorator
 import controllers.auth.requests.UserRequest
 import controllers.bindable.Origin
+import models.MyService
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.ArgumentMatchers.any
@@ -135,6 +136,23 @@ class HomeViewSpec extends ViewSpec {
 
       view must include(messages("label.home_page.utr"))
       view must include(utr)
+    }
+
+    "render combined Self Assessment and MTD supporting text in the current design" in {
+      implicit val userRequest: UserRequest[AnyContentAsEmpty.type] = buildUserRequest(request = FakeRequest())
+      val combinedService                                           = MyService(
+        messages("label.mtd_for_itsa"),
+        Some("/itsa"),
+        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
+        id = Some("itsa")
+      )
+
+      val document = asDocument(home(homeViewModel.copy(myServices = Seq(combinedService))).toString)
+
+      document.select("ul#my_taxes li#itsa a").text() mustBe messages("label.mtd_for_itsa")
+      document.select("ul#my_taxes li#itsa p.govuk-body").text() mustBe messages(
+        "label.view_and_manage_your_income_tax_obligations_and_payments"
+      )
     }
 
     "show the alert banner if there is some alert content" in {

--- a/test/views/html/HomeViewSpec.scala
+++ b/test/views/html/HomeViewSpec.scala
@@ -143,14 +143,16 @@ class HomeViewSpec extends ViewSpec {
       val combinedService                                           = MyService(
         messages("label.mtd_for_itsa"),
         Some("/itsa"),
-        Some(messages("label.view_manage_your_mtd_it")),
+        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
         id = Some("itsa")
       )
 
       val document = asDocument(home(homeViewModel.copy(myServices = Seq(combinedService))).toString)
 
       document.select("ul#my_taxes li#itsa a").text() mustBe messages("label.mtd_for_itsa")
-      document.select("ul#my_taxes li#itsa p.govuk-body").text() mustBe messages("label.view_manage_your_mtd_it")
+      document.select("ul#my_taxes li#itsa p.govuk-body").text() mustBe messages(
+        "label.view_and_manage_your_income_tax_obligations_and_payments"
+      )
     }
 
     "render Self Assessment other service supporting text in the current design" in {

--- a/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
+++ b/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
@@ -179,6 +179,22 @@ class TaxesAndBenefitsViewSpec extends ViewSpec {
       document.select("div.hmrc-card p.govuk-hint").text() mustBe "PAYE hint text"
     }
 
+    "render combined Self Assessment and MTD supporting text in the tabular redesign" in {
+      val combinedService = MyService(
+        messages("label.mtd_for_itsa"),
+        Some("/itsa"),
+        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
+        id = Some("itsa")
+      )
+
+      val document = asDocument(page(Seq(combinedService), Seq.empty).toString)
+
+      document.select("div.hmrc-card h4.hmrc-card__heading").text() mustBe messages("label.mtd_for_itsa")
+      document.select("div.hmrc-card p.govuk-hint").text() mustBe messages(
+        "label.view_and_manage_your_income_tax_obligations_and_payments"
+      )
+    }
+
     "render otherService hints when present" in {
       val childBenefitWithHint = childBenefitService.copy(hintText = Some("Child Benefit hint text"))
       val document             = asDocument(page(Seq.empty, Seq(childBenefitWithHint)).toString)

--- a/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
+++ b/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
@@ -183,14 +183,16 @@ class TaxesAndBenefitsViewSpec extends ViewSpec {
       val combinedService = MyService(
         messages("label.mtd_for_itsa"),
         Some("/itsa"),
-        Some(messages("label.view_manage_your_mtd_it")),
+        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
         id = Some("itsa")
       )
 
       val document = asDocument(page(Seq(combinedService), Seq.empty).toString)
 
       document.select("div.hmrc-card h4.hmrc-card__heading").text() mustBe messages("label.mtd_for_itsa")
-      document.select("div.hmrc-card p.govuk-hint").text() mustBe messages("label.view_manage_your_mtd_it")
+      document.select("div.hmrc-card p.govuk-hint").text() mustBe messages(
+        "label.view_and_manage_your_income_tax_obligations_and_payments"
+      )
     }
 
     "render otherService hints when present" in {

--- a/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
+++ b/test/views/html/home/options/TaxesAndBenefitsViewSpec.scala
@@ -183,16 +183,14 @@ class TaxesAndBenefitsViewSpec extends ViewSpec {
       val combinedService = MyService(
         messages("label.mtd_for_itsa"),
         Some("/itsa"),
-        Some(messages("label.view_and_manage_your_income_tax_obligations_and_payments")),
+        Some(messages("label.view_manage_your_mtd_it")),
         id = Some("itsa")
       )
 
       val document = asDocument(page(Seq(combinedService), Seq.empty).toString)
 
       document.select("div.hmrc-card h4.hmrc-card__heading").text() mustBe messages("label.mtd_for_itsa")
-      document.select("div.hmrc-card p.govuk-hint").text() mustBe messages(
-        "label.view_and_manage_your_income_tax_obligations_and_payments"
-      )
+      document.select("div.hmrc-card p.govuk-hint").text() mustBe messages("label.view_manage_your_mtd_it")
     }
 
     "render otherService hints when present" in {


### PR DESCRIPTION
 - Updated the combined Self Assessment and Making Tax Digital for Income Tax label order.
  - Updated the Welsh translation for the combined label.
  - Added/verified service descriptions for the current and other service tiles in the taxes and benefits redesign.
  - Added coverage for HMRC-MTD-IT enrolment scenarios and Welsh combined-label content.