### PR TITLE
PTAD-247 Disable Home Change Banner Toggle in Live and Beta

### DIFF
--- a/app/models/admin/FeatureFlags.scala
+++ b/app/models/admin/FeatureFlags.scala
@@ -213,6 +213,8 @@ case object HomePageChangesBannerToggle extends FeatureFlagName {
   override val description: Option[String] = Some(
     "Enable/disable the banner on PTA home page informing users about changes made to the home page design"
   )
+  override val lockedEnvironments: Seq[Environment] = Seq(Environment.Production, Environment.Staging)
+  override val defaultState: Boolean = false
 }
 
 case object HomePagePersonalisationToggle extends FeatureFlagName {


### PR DESCRIPTION
## Summary
Disable the Home Change Banner Toggle in Live (Production) and Beta (Staging) environments to prevent users from seeing incorrect content.

## Problem
The banner was displaying a link to "Find out what's changed" which directed users to the Child Benefit news item due to an expired news item (end-date: 27/7/26). This caused confusion as users expected to see homepage update information.

## Solution
Modified `HomePageChangesBannerToggle` to:
- Lock the toggle in Production and Staging environments (cannot be enabled)
- Set default state to false (disabled)
- Banner will no longer display on Live and Beta

## Test Plan
- ✅ Code change verified: toggle now has locked environments for Production/Staging
- ✅ Default state set to false
- ✅ AlertBannerHelper will return None when toggle is disabled
- ✅ Banner will not render on Live and Beta environments

🤖 Generated with Claude Code