### PR TITLE
PTAD-185 Return Tasks for the Your Tasks tab

### DIFF
--- a/app/config/ConfigDecorator.scala
+++ b/app/config/ConfigDecorator.scala
@@ -255,10 +255,6 @@ class ConfigDecorator @Inject() (
 
   lazy val breathingSpaceBaseUrl: String                 = servicesConfig.baseUrl("breathing-space-if-proxy")
   private lazy val tasksAndActivitiesBaseUrl: String     = servicesConfig.baseUrl("pta-tasks-and-events")
-  private lazy val tasksAndActivitiesPath: String        =
-    runModeConfiguration
-      .getOptional[String]("tasks-and-activities.tasks-path")
-      .getOrElse("/pta-tasks-and-events/:nino/tasks")
   lazy val breathingSpaceTimeoutInMilliseconds: Int      =
     servicesConfig.getInt("microservice.services.breathing-space-if-proxy.timeoutInMilliseconds")
   lazy val tasksAndActivitiesTimeoutInMilliseconds: Int  =
@@ -289,7 +285,7 @@ class ConfigDecorator @Inject() (
   val mongoEncryptionEnabled: Boolean = runModeConfiguration.get[Boolean]("mongodb.encryption.enabled")
 
   def tasksAndActivitiesTasksUrl(nino: Nino): String =
-    s"$tasksAndActivitiesBaseUrl${tasksAndActivitiesPath.replace(":nino", nino.nino)}"
+    s"$tasksAndActivitiesBaseUrl/pta-tasks-and-events/${nino.nino}/tasks"
 
   val payeToPegaRedirectList: Seq[Int] = runModeConfiguration.get[Seq[Int]]("paye.to.pega.redirect.list")
   val payeToPegaRedirectUrl: String    = runModeConfiguration.get[String]("paye.to.pega.redirect.url")

--- a/app/config/ConfigDecorator.scala
+++ b/app/config/ConfigDecorator.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.net.{URL, URLEncoder}
 import java.time.LocalDate
+import uk.gov.hmrc.domain.Nino
 
 @Singleton
 class ConfigDecorator @Inject() (
@@ -253,8 +254,15 @@ class ConfigDecorator @Inject() (
     runModeConfiguration.getOptional[String]("feature.alert-shuttering.page.paragraph.cy").getOrElse("")
 
   lazy val breathingSpaceBaseUrl: String                 = servicesConfig.baseUrl("breathing-space-if-proxy")
+  private lazy val tasksAndActivitiesBaseUrl: String     = servicesConfig.baseUrl("pta-tasks-and-events")
+  private lazy val tasksAndActivitiesPath: String        =
+    runModeConfiguration
+      .getOptional[String]("tasks-and-activities.tasks-path")
+      .getOrElse("/pta-tasks-and-events/:nino/tasks")
   lazy val breathingSpaceTimeoutInMilliseconds: Int      =
     servicesConfig.getInt("microservice.services.breathing-space-if-proxy.timeoutInMilliseconds")
+  lazy val tasksAndActivitiesTimeoutInMilliseconds: Int  =
+    servicesConfig.getInt("microservice.services.pta-tasks-and-events.timeoutInMilliseconds")
   lazy val citizenDetailsTimeoutInMilliseconds: Int      =
     servicesConfig.getInt("microservice.services.citizen-details.timeoutInMilliseconds")
   lazy val taiTimeoutInMilliseconds: Int                 =
@@ -279,6 +287,9 @@ class ConfigDecorator @Inject() (
     servicesConfig.getBoolean("feature.pegaSaRegistration.enabled")
 
   val mongoEncryptionEnabled: Boolean = runModeConfiguration.get[Boolean]("mongodb.encryption.enabled")
+
+  def tasksAndActivitiesTasksUrl(nino: Nino): String =
+    s"$tasksAndActivitiesBaseUrl${tasksAndActivitiesPath.replace(":nino", nino.nino)}"
 
   val payeToPegaRedirectList: Seq[Int] = runModeConfiguration.get[Seq[Int]]("paye.to.pega.redirect.list")
   val payeToPegaRedirectUrl: String    = runModeConfiguration.get[String]("paye.to.pega.redirect.url")

--- a/app/connectors/TasksAndActivitiesConnector.scala
+++ b/app/connectors/TasksAndActivitiesConnector.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import cats.data.EitherT
+import com.google.inject.Inject
+import config.ConfigDecorator
+import play.api.Logging
+import play.api.http.Status.BAD_GATEWAY
+import play.api.libs.json.{JsArray, JsError, JsObject, JsResult, JsString, JsSuccess, JsValue, Reads}
+import uk.gov.hmrc.domain.Nino
+import uk.gov.hmrc.http.HttpReads.Implicits.{readEitherOf, readRaw}
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps, UpstreamErrorResponse}
+import viewmodels.{Task, TaskStatus}
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+class TasksAndActivitiesConnector @Inject() (
+  httpClientV2: HttpClientV2,
+  httpClientResponse: HttpClientResponse,
+  configDecorator: ConfigDecorator
+) extends Logging {
+
+  def getTasks(nino: Nino)(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): EitherT[Future, UpstreamErrorResponse, Seq[Task]] = {
+    val url = configDecorator.tasksAndActivitiesTasksUrl(nino)
+
+    EitherT(
+      httpClientResponse
+        .read(
+          httpClientV2
+            .get(url"$url")
+            .transform(_.withRequestTimeout(configDecorator.tasksAndActivitiesTimeoutInMilliseconds.milliseconds))
+            .execute[Either[UpstreamErrorResponse, HttpResponse]](readEitherOf(readRaw), ec)
+        )
+        .value
+        .map {
+          case Right(response) => parseTasks(response)
+          case Left(error)    => Left(error)
+        }
+    )
+  }
+
+  private def parseTasks(response: HttpResponse): Either[UpstreamErrorResponse, Seq[Task]] =
+    Try(response.json).toEither.left
+      .map { error =>
+        logger.error("Unable to read Tasks and Activities response as JSON", error)
+        UpstreamErrorResponse("Unable to read Tasks and Activities response as JSON", BAD_GATEWAY, BAD_GATEWAY)
+      }
+      .flatMap { json =>
+        json.validate[TasksAndActivitiesResponse].asEither.left.map { errors =>
+          logger.error(s"Unable to parse Tasks and Activities response: ${JsError.toJson(errors)}")
+          UpstreamErrorResponse("Unable to parse Tasks and Activities response", BAD_GATEWAY, BAD_GATEWAY)
+        }
+      }
+      .map(_.tasks.map(_.toTask))
+}
+
+private final case class TasksAndActivitiesResponse(tasks: Seq[TasksAndActivitiesTask])
+
+private object TasksAndActivitiesResponse {
+  implicit val reads: Reads[TasksAndActivitiesResponse] = Reads {
+    case json: JsObject => (json \ "tasks").validate[Seq[TasksAndActivitiesTask]].map(TasksAndActivitiesResponse(_))
+    case json: JsArray  => json.validate[Seq[TasksAndActivitiesTask]].map(TasksAndActivitiesResponse(_))
+    case _              => JsError("Expected Tasks and Activities response to be an object or array")
+  }
+}
+
+private final case class TasksAndActivitiesTask(
+  title: String,
+  href: String,
+  status: TaskStatus,
+  hintText: Option[String]
+) {
+  def toTask: Task = Task(title, status, href, hintText)
+}
+
+private object TasksAndActivitiesTask {
+  implicit val reads: Reads[TasksAndActivitiesTask] = Reads { json =>
+    for {
+      title    <- readString(json, "title")
+      href     <- readString(json, "href").orElse(readString(json, "url"))
+      status   <- readStatus(json)
+      hintText <- (json \ "hintText").validateOpt[String]
+    } yield TasksAndActivitiesTask(title, href, status, hintText)
+  }
+
+  private def readString(json: JsValue, fieldName: String): JsResult[String] =
+    (json \ fieldName).validate[String]
+
+  private def readStatus(json: JsValue): JsResult[TaskStatus] =
+    (json \ "status").validateOpt[TaskStatus].map(_.getOrElse(TaskStatus.Incomplete))
+
+  implicit val taskStatusReads: Reads[TaskStatus] = Reads {
+    case JsString(value) =>
+      value.trim.toLowerCase match {
+        case "incomplete" | "open" | "todo" | "to-do" | "not-started" => JsSuccess(TaskStatus.Incomplete)
+        case "completed" | "complete" | "done"                       => JsSuccess(TaskStatus.Completed)
+        case _                                                        => JsError(s"Unsupported task status: $value")
+      }
+    case _               => JsError("Expected task status to be a string")
+  }
+}

--- a/app/connectors/TasksAndActivitiesConnector.scala
+++ b/app/connectors/TasksAndActivitiesConnector.scala
@@ -55,7 +55,7 @@ class TasksAndActivitiesConnector @Inject() (
         .value
         .map {
           case Right(response) => parseTasks(response)
-          case Left(error)    => Left(error)
+          case Left(error)     => Left(error)
         }
     )
   }
@@ -114,7 +114,7 @@ private object TasksAndActivitiesTask {
     case JsString(value) =>
       value.trim.toLowerCase match {
         case "incomplete" | "open" | "todo" | "to-do" | "not-started" => JsSuccess(TaskStatus.Incomplete)
-        case "completed" | "complete" | "done"                       => JsSuccess(TaskStatus.Completed)
+        case "completed" | "complete" | "done"                        => JsSuccess(TaskStatus.Completed)
         case _                                                        => JsError(s"Unsupported task status: $value")
       }
     case _               => JsError("Expected task status to be a string")

--- a/app/models/admin/FeatureFlags.scala
+++ b/app/models/admin/FeatureFlags.scala
@@ -42,7 +42,8 @@ object AllFeatureFlags {
     ClaimMtdFromPtaToggle,
     HomePageChangesBannerToggle,
     HomePagePersonalisationToggle,
-    PtapActivityTabToggle
+    PtapActivityTabToggle,
+    TasksAndActivitiesServiceToggle
   )
 }
 
@@ -231,4 +232,12 @@ case object PtapActivityTabToggle extends FeatureFlagName {
   )
   override val lockedEnvironments: Seq[Environment] =
     Seq(Environment.Local, Environment.Staging, Environment.Qa, Environment.Production)
+}
+
+case object TasksAndActivitiesServiceToggle extends FeatureFlagName {
+  override val name: String                = "tasks-and-activities-service-toggle"
+  override val description: Option[String] = Some(
+    "Enable retrieval of Your Tasks tab data from the PTA Tasks and Events service"
+  )
+  override val defaultState: Boolean       = false
 }

--- a/app/services/TasksService.scala
+++ b/app/services/TasksService.scala
@@ -16,14 +16,17 @@
 
 package services
 
+import connectors.TasksAndActivitiesConnector
 import com.google.inject.Inject
 import config.ConfigDecorator
 import controllers.Execution.trampoline
-import models.admin.ShowTaxCalcTileToggle
+import models.admin.{ShowTaxCalcTileToggle, TasksAndActivitiesServiceToggle}
 import controllers.auth.requests.UserRequest
 import play.api.i18n.Messages
 import services.partials.TaxCalcPartialService
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongoFeatureToggles.services.FeatureFlagService
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import viewmodels.{Task, TaskStatus}
 import models.*
 import play.api.Logging
@@ -33,12 +36,52 @@ import scala.concurrent.Future
 class TasksService @Inject() (
   configDecorator: ConfigDecorator,
   taxCalcPartialService: TaxCalcPartialService,
-  featureFlagService: FeatureFlagService
+  featureFlagService: FeatureFlagService,
+  tasksAndActivitiesConnector: TasksAndActivitiesConnector
 ) extends Logging {
 
-  def getListOfTasks(implicit request: UserRequest[?], messages: Messages): Future[Seq[Task]] = {
-    val taxcalcF = getTaxCalcTasks(request.trustedHelper.isDefined)
+  def getListOfTasks(implicit request: UserRequest[?], messages: Messages): Future[Seq[Task]] =
+    if (request.trustedHelper.isDefined) {
+      Future.successful(Seq.empty)
+    } else {
+      featureFlagService
+        .get(TasksAndActivitiesServiceToggle)
+        .flatMap { tasksAndActivitiesFlag =>
+          if (tasksAndActivitiesFlag.isEnabled) {
+            getTasksAndActivitiesTasks
+          } else {
+            getExistingTasks
+          }
+        }
+        .recoverWith { case error =>
+          logger.error("Unable to retrieve Tasks and Activities Service toggle. Using existing task logic.", error)
+          getExistingTasks
+        }
+    }
+
+  private def getExistingTasks(implicit request: UserRequest[?], messages: Messages): Future[Seq[Task]] = {
+    val taxcalcF = getTaxCalcTasks(isTrustedHelper = false)
     Future.sequence(Seq(taxcalcF)).map(_.flatten)
+  }
+
+  private def getTasksAndActivitiesTasks(implicit request: UserRequest[?]): Future[Seq[Task]] = {
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+
+    tasksAndActivitiesConnector
+      .getTasks(request.authNino)
+      .value
+      .map {
+        case Right(tasks) => tasks
+        case Left(error)  =>
+          logger.error(
+            s"Unable to retrieve tasks from Tasks and Activities service. Status: ${error.statusCode}. Message: ${error.message}"
+          )
+          Seq.empty
+      }
+      .recover { case error =>
+        logger.error("Unexpected error retrieving tasks from Tasks and Activities service", error)
+        Seq.empty
+      }
   }
 
   def getTaxCalcTasks(

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -105,6 +105,15 @@ microservice {
       port = 9331
       timeoutInMilliseconds = 500
     }
+    low-earners-pensions-payment-frontend {
+      host = localhost
+      port = 7503
+    }
+    low-earners-pensions-payment {
+      host = localhost
+      port = 7504
+      timeoutInMilliseconds = 500
+    }
     pertax-frontend {
       host = localhost
       port = 9232
@@ -130,6 +139,11 @@ microservice {
       host = localhost
       port = 9416
       timeoutInMilliseconds = 5000
+    }
+    pta-tasks-and-events {
+      host = localhost
+      port = 1701
+      timeoutInMilliseconds = 2000
     }
     preferences-frontend {
       host = localhost
@@ -201,6 +215,10 @@ microservice {
       port = 9216
     }
   }
+}
+
+tasks-and-activities {
+  tasks-path = "/pta-tasks-and-events/:nino/tasks"
 }
 
 external-url {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -217,10 +217,6 @@ microservice {
   }
 }
 
-tasks-and-activities {
-  tasks-path = "/pta-tasks-and-events/:nino/tasks"
-}
-
 external-url {
   child-benefits {
     view-proof-entitlement-location = "http://localhost:10650/child-benefit/view-proof-entitlement"

--- a/test/connectors/TasksAndActivitiesConnectorSpec.scala
+++ b/test/connectors/TasksAndActivitiesConnectorSpec.scala
@@ -97,7 +97,9 @@ class TasksAndActivitiesConnectorSpec extends ConnectorSpec with WireMockHelper 
 
       val result = connector.getTasks(generatedNino).value.futureValue
 
-      result mustBe Right(Seq(Task("You owe £500 for tax year 2026 to 2027", TaskStatus.Incomplete, "/tax-you-paid", None)))
+      result mustBe Right(
+        Seq(Task("You owe £500 for tax year 2026 to 2027", TaskStatus.Incomplete, "/tax-you-paid", None))
+      )
     }
 
     List(BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND).foreach { statusCode =>

--- a/test/connectors/TasksAndActivitiesConnectorSpec.scala
+++ b/test/connectors/TasksAndActivitiesConnectorSpec.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock.{getRequestedFor, urlEqualTo}
+import play.api.Application
+import testUtils.WireMockHelper
+import uk.gov.hmrc.http.UpstreamErrorResponse
+import viewmodels.{Task, TaskStatus}
+
+class TasksAndActivitiesConnectorSpec extends ConnectorSpec with WireMockHelper {
+
+  private val url = s"/pta-tasks-and-events/${generatedNino.nino}/tasks"
+
+  override implicit lazy val app: Application = app(
+    Map(
+      "microservice.services.pta-tasks-and-events.port"                  -> server.port(),
+      "microservice.services.pta-tasks-and-events.timeoutInMilliseconds" -> 5000
+    )
+  )
+
+  private def connector: TasksAndActivitiesConnector = app.injector.instanceOf[TasksAndActivitiesConnector]
+
+  "getTasks" must {
+    "return tasks from a successful object response" in {
+      val response =
+        """
+          |{
+          |  "tasks": [
+          |    {
+          |      "title": "You owe £500 for tax year 2026 to 2027",
+          |      "status": "incomplete",
+          |      "href": "/tax-you-paid",
+          |      "hintText": "You should pay this now"
+          |    },
+          |    {
+          |      "title": "Refund claimed",
+          |      "status": "completed",
+          |      "href": "/tax-you-paid/refund"
+          |    }
+          |  ]
+          |}
+          |""".stripMargin
+
+      stubGet(url, OK, Some(response))
+
+      val result = connector.getTasks(generatedNino).value.futureValue
+
+      result mustBe Right(
+        Seq(
+          Task(
+            "You owe £500 for tax year 2026 to 2027",
+            TaskStatus.Incomplete,
+            "/tax-you-paid",
+            Some("You should pay this now")
+          ),
+          Task("Refund claimed", TaskStatus.Completed, "/tax-you-paid/refund", None)
+        )
+      )
+      server.verify(getRequestedFor(urlEqualTo(url)))
+    }
+
+    "return an empty sequence when the service returns no tasks" in {
+      stubGet(url, OK, Some("""{"tasks": []}"""))
+
+      val result = connector.getTasks(generatedNino).value.futureValue
+
+      result mustBe Right(Seq.empty)
+    }
+
+    "return tasks from an array response" in {
+      val response =
+        """
+          |[
+          |  {
+          |    "title": "You owe £500 for tax year 2026 to 2027",
+          |    "href": "/tax-you-paid"
+          |  }
+          |]
+          |""".stripMargin
+
+      stubGet(url, OK, Some(response))
+
+      val result = connector.getTasks(generatedNino).value.futureValue
+
+      result mustBe Right(Seq(Task("You owe £500 for tax year 2026 to 2027", TaskStatus.Incomplete, "/tax-you-paid", None)))
+    }
+
+    List(BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND).foreach { statusCode =>
+      s"return an UpstreamErrorResponse when $statusCode is returned" in {
+        stubGet(url, statusCode, Some("""{"reason":"failed"}"""))
+
+        val result = connector.getTasks(generatedNino).value.futureValue
+
+        result mustBe a[Left[UpstreamErrorResponse, _]]
+      }
+    }
+
+    "return an UpstreamErrorResponse when the response cannot be parsed" in {
+      stubGet(url, OK, Some("""{"tasks": [{"title": "Missing href"}]}"""))
+
+      val result = connector.getTasks(generatedNino).value.futureValue
+
+      result mustBe a[Left[UpstreamErrorResponse, _]]
+      result.swap.exists(_.statusCode == BAD_GATEWAY) mustBe true
+    }
+  }
+}

--- a/test/services/TasksServiceSpec.scala
+++ b/test/services/TasksServiceSpec.scala
@@ -16,9 +16,11 @@
 
 package services
 
+import cats.data.EitherT
+import connectors.TasksAndActivitiesConnector
 import config.ConfigDecorator
 import controllers.auth.requests.UserRequest
-import models.admin.ShowTaxCalcTileToggle
+import models.admin.{ShowTaxCalcTileToggle, TasksAndActivitiesServiceToggle}
 import models.*
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
@@ -31,6 +33,7 @@ import services.partials.TaxCalcPartialService
 import testUtils.BaseSpec
 import uk.gov.hmrc.auth.core.ConfidenceLevel
 import uk.gov.hmrc.auth.core.retrieve.Credentials
+import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.mongoFeatureToggles.model.FeatureFlag
 import uk.gov.hmrc.mongoFeatureToggles.services.FeatureFlagService
 import viewmodels.{Task, TaskStatus}
@@ -42,9 +45,15 @@ class TasksServiceSpec extends BaseSpec {
   private val mockConfigDecorator: ConfigDecorator             = mock[ConfigDecorator]
   private val mockTaxCalcPartialService: TaxCalcPartialService = mock[TaxCalcPartialService]
   private val mockFeatureFlagService: FeatureFlagService       = mock[FeatureFlagService]
+  private val mockTasksAndActivitiesConnector                  = mock[TasksAndActivitiesConnector]
 
   private lazy val service: TasksService =
-    new TasksService(mockConfigDecorator, mockTaxCalcPartialService, mockFeatureFlagService)
+    new TasksService(
+      mockConfigDecorator,
+      mockTaxCalcPartialService,
+      mockFeatureFlagService,
+      mockTasksAndActivitiesConnector
+    )
   implicit lazy val messages: Messages   = MessagesImpl(Lang("en"), messagesApi)
 
   override def beforeEach(): Unit = {
@@ -52,6 +61,7 @@ class TasksServiceSpec extends BaseSpec {
     reset(mockConfigDecorator)
     reset(mockFeatureFlagService)
     reset(mockTaxCalcPartialService)
+    reset(mockTasksAndActivitiesConnector)
   }
 
   val overpaid: String =
@@ -79,6 +89,107 @@ class TasksServiceSpec extends BaseSpec {
       |<p class="govuk-body">You should have paid by 19 February 2018 but you can still make a payment now.</p>
       |  </div>
       |""".stripMargin
+
+  private def userRequest: UserRequest[AnyContent] = UserRequest(
+    generatedNino,
+    NonFilerSelfAssessmentUser,
+    Credentials("credId", "GovernmentGateway"),
+    ConfidenceLevel.L200,
+    None,
+    Set.empty,
+    None,
+    None,
+    FakeRequest(),
+    UserAnswers.empty
+  )
+
+  "getListOfTasks" when {
+    "the Tasks and Activities Service toggle is disabled" must {
+      "use the existing task logic" in {
+        implicit val request: UserRequest[AnyContent] = userRequest
+        when(mockConfigDecorator.taxCalcHomePageUrl).thenReturn("http://link/to/taxcalc")
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(TasksAndActivitiesServiceToggle)))
+          .thenReturn(Future.successful(FeatureFlag(TasksAndActivitiesServiceToggle, false)))
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(ShowTaxCalcTileToggle)))
+          .thenReturn(Future.successful(FeatureFlag(ShowTaxCalcTileToggle, true)))
+        when(mockTaxCalcPartialService.getTaxCalcPartial(any())).thenReturn(
+          Future.successful(Seq(SummaryCardPartial("tc1", Html(underpaid), Underpaid, 2026)))
+        )
+
+        val result = service.getListOfTasks.futureValue
+
+        result mustBe Seq(
+          Task("You owe £500 for tax year 2026 to 2027", TaskStatus.Incomplete, "http://link/to/taxcalc", None)
+        )
+        verify(mockTasksAndActivitiesConnector, times(0)).getTasks(any())(any(), any())
+      }
+    }
+
+    "the Tasks and Activities Service toggle is enabled" must {
+      "return tasks from the Tasks and Activities service" in {
+        implicit val request: UserRequest[AnyContent] = userRequest
+        val tasks                                     =
+          Seq(Task("You owe £500 for tax year 2026 to 2027", TaskStatus.Incomplete, "/tax-you-paid", None))
+
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(TasksAndActivitiesServiceToggle)))
+          .thenReturn(Future.successful(FeatureFlag(TasksAndActivitiesServiceToggle, true)))
+        when(mockTasksAndActivitiesConnector.getTasks(ArgumentMatchers.eq(generatedNino))(any(), any()))
+          .thenReturn(EitherT.rightT[Future, UpstreamErrorResponse](tasks))
+
+        val result = service.getListOfTasks.futureValue
+
+        result mustBe tasks
+        verify(mockTaxCalcPartialService, times(0)).getTaxCalcPartial(any())
+      }
+
+      "handle an empty response from the Tasks and Activities service" in {
+        implicit val request: UserRequest[AnyContent] = userRequest
+
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(TasksAndActivitiesServiceToggle)))
+          .thenReturn(Future.successful(FeatureFlag(TasksAndActivitiesServiceToggle, true)))
+        when(mockTasksAndActivitiesConnector.getTasks(ArgumentMatchers.eq(generatedNino))(any(), any()))
+          .thenReturn(EitherT.rightT[Future, UpstreamErrorResponse](Seq.empty[Task]))
+
+        val result = service.getListOfTasks.futureValue
+
+        result mustBe Seq.empty
+      }
+
+      "handle an error from the Tasks and Activities service" in {
+        implicit val request: UserRequest[AnyContent] = userRequest
+
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(TasksAndActivitiesServiceToggle)))
+          .thenReturn(Future.successful(FeatureFlag(TasksAndActivitiesServiceToggle, true)))
+        when(mockTasksAndActivitiesConnector.getTasks(ArgumentMatchers.eq(generatedNino))(any(), any()))
+          .thenReturn(EitherT.leftT[Future, Seq[Task]](UpstreamErrorResponse("service unavailable", 503)))
+
+        val result = service.getListOfTasks.futureValue
+
+        result mustBe Seq.empty
+        verify(mockTaxCalcPartialService, times(0)).getTaxCalcPartial(any())
+      }
+    }
+
+    "the Tasks and Activities Service toggle cannot be retrieved" must {
+      "log the toggle issue and use the existing task logic" in {
+        implicit val request: UserRequest[AnyContent] = userRequest
+        when(mockConfigDecorator.taxCalcHomePageUrl).thenReturn("http://link/to/taxcalc")
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(TasksAndActivitiesServiceToggle)))
+          .thenReturn(Future.failed(new RuntimeException("toggle unavailable")))
+        when(mockFeatureFlagService.get(ArgumentMatchers.eq(ShowTaxCalcTileToggle)))
+          .thenReturn(Future.successful(FeatureFlag(ShowTaxCalcTileToggle, true)))
+        when(mockTaxCalcPartialService.getTaxCalcPartial(any())).thenReturn(
+          Future.successful(Seq(SummaryCardPartial("tc1", Html(underpaid), Underpaid, 2026)))
+        )
+
+        val result = service.getListOfTasks.futureValue
+
+        result mustBe Seq(
+          Task("You owe £500 for tax year 2026 to 2027", TaskStatus.Incomplete, "http://link/to/taxcalc", None)
+        )
+      }
+    }
+  }
 
   "getTaxcalcTasks" when {
     "trusted helper is disable" must {


### PR DESCRIPTION
- Added `TasksAndActivitiesConnector` to call `pta-tasks-and-events`.
- Added `tasks-and-activities-service-toggle`, defaulted off for controlled rollout.
- Updated `TasksService` to:
  - keep existing task logic when the toggle is off
  - call the new service when the toggle is on
  - fall back to existing logic if the toggle cannot be retrieved
  - handle service errors and empty responses safely
- Maps the new service response into the existing `Task` view model so the frontend presentation remains unchanged.
- Added connector and service tests for success, empty response, errors, and toggle behaviour.
