### PR TITLE
PTAD-239 url config test

### DIFF
--- a/app/config/ConfigDecorator.scala
+++ b/app/config/ConfigDecorator.scala
@@ -56,7 +56,6 @@ class ConfigDecorator @Inject() (
   private lazy val formFrontendService     = servicesConfig.baseUrl("dfs-digital-forms-frontend")
   private lazy val taxCalcFrontendService  = servicesConfig.baseUrl("taxcalc-frontend")
   private lazy val taxCalcFrontendExternal = getExternalUrl("taxcalc-frontend.host").getOrElse("")
-  private lazy val leppFrontendService     = servicesConfig.baseUrl("low-earners-pensions-payment-frontend")
 
   lazy val businessTaxAccountService: String = servicesConfig.baseUrl("business-tax-account")
 
@@ -305,10 +304,11 @@ class ConfigDecorator @Inject() (
   lazy val mtdGuidanceUrl: String = runModeConfiguration.get[String]("external-url.mtd-guidance.url")
 
   lazy val leppStartUrl: String =
-    s"$leppFrontendService/accept-your-low-earners-pension-payment/start"
+    runModeConfiguration.get[String]("external-url.lepp.url")
 
   lazy val leppPaymentsUrl: String =
-    s"$leppFrontendService/accept-your-low-earners-pension-payment/payments"
+    runModeConfiguration.getOptional[String]("external-url.lepp.paymentsUrl")
+      .getOrElse(leppStartUrl.replace("start", "payments"))
 
   lazy val addressChangeBannerTextEn: String       =
     runModeConfiguration.get[String]("feature.address-change-error.banner.paragraph.en")

--- a/app/config/ConfigDecorator.scala
+++ b/app/config/ConfigDecorator.scala
@@ -307,7 +307,8 @@ class ConfigDecorator @Inject() (
     runModeConfiguration.get[String]("external-url.lepp.url")
 
   lazy val leppPaymentsUrl: String =
-    runModeConfiguration.getOptional[String]("external-url.lepp.paymentsUrl")
+    runModeConfiguration
+      .getOptional[String]("external-url.lepp.paymentsUrl")
       .getOrElse(leppStartUrl.replace("start", "payments"))
 
   lazy val addressChangeBannerTextEn: String       =


### PR DESCRIPTION
Align LEPP URL configuration to use relative paths in staging/prod, eliminating 
config duplication. Local uses full URL; other environments use relative paths 
that the reverse proxy routes automatically.