### PR TITLE
PTAD-239  : read URLs from config 

### DIFF
--- a/app/config/ConfigDecorator.scala
+++ b/app/config/ConfigDecorator.scala
@@ -56,7 +56,6 @@ class ConfigDecorator @Inject() (
   private lazy val formFrontendService     = servicesConfig.baseUrl("dfs-digital-forms-frontend")
   private lazy val taxCalcFrontendService  = servicesConfig.baseUrl("taxcalc-frontend")
   private lazy val taxCalcFrontendExternal = getExternalUrl("taxcalc-frontend.host").getOrElse("")
-  private lazy val leppFrontendService     = servicesConfig.baseUrl("low-earners-pensions-payment-frontend")
 
   lazy val businessTaxAccountService: String = servicesConfig.baseUrl("business-tax-account")
 
@@ -305,10 +304,12 @@ class ConfigDecorator @Inject() (
   lazy val mtdGuidanceUrl: String = runModeConfiguration.get[String]("external-url.mtd-guidance.url")
 
   lazy val leppStartUrl: String =
-    s"$leppFrontendService/accept-your-low-earners-pension-payment/start"
+    runModeConfiguration.get[String]("external-url.lepp.url")
 
   lazy val leppPaymentsUrl: String =
-    s"$leppFrontendService/accept-your-low-earners-pension-payment/payments"
+    runModeConfiguration
+      .getOptional[String]("external-url.lepp.paymentsUrl")
+      .getOrElse(leppStartUrl.replace("start", "payments"))
 
   lazy val addressChangeBannerTextEn: String       =
     runModeConfiguration.get[String]("feature.address-change-error.banner.paragraph.en")


### PR DESCRIPTION
Replace servicesConfig.baseUrl() construction with direct config reads from external-url.lepp.url. 