### PR TITLE
PTAD-239 : hange leppUrl from nested (lepp { url }) to flat format (leppUrl)

### DIFF
--- a/app/config/ConfigDecorator.scala
+++ b/app/config/ConfigDecorator.scala
@@ -304,7 +304,7 @@ class ConfigDecorator @Inject() (
   lazy val mtdGuidanceUrl: String = runModeConfiguration.get[String]("external-url.mtd-guidance.url")
 
   lazy val leppStartUrl: String =
-    runModeConfiguration.get[String]("external-url.lepp.url")
+    runModeConfiguration.get[String]("external-url.leppUrl")
 
   lazy val leppPaymentsUrl: String =
     runModeConfiguration

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -292,9 +292,7 @@ external-url {
   mtd-guidance {
     url = "https://www.gov.uk/government/publications/extension-of-making-tax-digital-for-income-tax-self-assessment-to-sole-traders-and-landlords/making-tax-digital-for-income-tax-self-assessment-for-sole-traders-and-landlords"
   }
-  lepp {
-    url = "http://localhost:7503/accept-your-low-earners-pension-payment/start"
-  }
+  leppUrl = "http://localhost:7503/accept-your-low-earners-pension-payment/start"
   bppSpreadTheCostAdvancePaymentUrl = "https://www.gov.uk/pay-self-assessment-tax-bill/pay-weekly-monthly"
 }
 


### PR DESCRIPTION
Change leppUrl from nested (lepp { url }) to flat format (leppUrl)
to match app-config-base convention. ConfigDecorator already reads
from external-url.leppUrl, so this aligns the local config accordingly.